### PR TITLE
Passes charmcraft token as variable in publish action

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: canonical/charming-actions/channel@2.2.5
         id: channel
       - name: Upload charm to Charmhub
-        env:
-          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
-        run: charmcraft upload ./tls-certificates-requirer_ubuntu-22.04-amd64.charm --release ${{ steps.channel.outputs.name }}
+        uses: canonical/charming-actions/upload-charm@2.2.5
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,6 +2,10 @@ name: publish-charm
 
 on:
   workflow_call:
+    inputs:
+      charmcraft-token:
+        required: true
+        type: string
 
 jobs:
   publish-charm:
@@ -21,8 +25,6 @@ jobs:
         uses: canonical/charming-actions/channel@2.2.5
         id: channel
       - name: Upload charm to Charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.5
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+        env:
+          CHARMCRAFT_AUTH: ${{ inputs.charmcraft-token }}
+        run: charmcraft upload ./tls-certificates-requirer_ubuntu-22.04-amd64.charm --release ${{ steps.channel.outputs.name }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,3 +22,5 @@ jobs:
       [lint-report, static-analysis, unit-tests-with-coverage, integration-test]
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
+    with:
+      charmcraft-token: ${{ secrets.CHARMCRAFT_AUTH }}


### PR DESCRIPTION
## Overview
Passes charmcraft token as variable in publish action

Reason: Environment Secrets are not available on Reusable Workflow
