### PR TITLE
Fixes the name of the operator in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ This charm is useful when developing and testing certificate providers.
 Deploy the charm and relate it to a certificate provider:
 
 ```bash
-juju deploy tls-requirer-operator
-juju relate tls-requirer-operator <TLS Certificates Provider>
+juju deploy tls-certificates-requirer
+juju relate tls-certificates-requirer <TLS Certificates Provider>
 ```
 
 Access the generated certificate:
 
 ```bash
-juju run tls-requirer-operator/leader get-certificate
+juju run tls-certificates-requirer/leader get-certificate
 ```
 
 ## Limitations


### PR DESCRIPTION
# Description

Fixes the name of the operator in the README:
- Uses the actual registered name of the charm

When deploying the charm using the current names from README it results in the following error:
```
juju deploy tls-requirer-operator
ERROR resolving error: The Charm with the given name was not found in the Store.
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
