### PR TITLE
Loads the list of chain certificates from json

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -286,7 +286,7 @@ class TLSRequirerOperatorCharm(CharmBase):
                 {
                     "certificate": content["certificate"],
                     "ca-certificate": content["ca-certificate"],
-                    "chain": content["chain"],
+                    "chain": json.loads(content["chain"]),
                     "csr": content["csr"],
                 }
             )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -293,7 +293,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         certificate = "whatever certificate"
         ca = "whatever ca"
-        chain = "whatever chain"
+        chain = ["whatever chain"]
         csr = "whatever csr"
         event = Mock()
         self.harness._backend.secret_add(
@@ -301,7 +301,7 @@ class TestCharm(unittest.TestCase):
             content={
                 "certificate": certificate,
                 "ca-certificate": ca,
-                "chain": chain,
+                "chain": json.dumps(chain),
                 "csr": csr,
             },
         )


### PR DESCRIPTION
# Description

The `chain` is being json dumped when stored in the juju-secret, this pr does the reverse of that when reading the chain from the secret and calls `json.loads` to get a list instead of one string.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
