### PR TITLE
Certificate creation request needs to wait for CSR generation

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,9 +276,11 @@ import copy
 import json
 import logging
 import uuid
+from collections import defaultdict
+from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
@@ -292,9 +294,12 @@ from ops.charm import (
     CharmEvents,
     RelationBrokenEvent,
     RelationChangedEvent,
+    SecretExpiredEvent,
     UpdateStatusEvent,
 )
 from ops.framework import EventBase, EventSource, Handle, Object
+from ops.jujuversion import JujuVersion
+from ops.model import SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
@@ -304,7 +309,9 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 10
+
+PYDEPS = ["cryptography", "jsonschema"]
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1019,6 +1026,8 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             None
         """
+        if not self.model.unit.is_leader():
+            return
         certificates_relation = self.model.get_relation(
             relation_name=self.relationship_name, relation_id=relation_id
         )
@@ -1051,8 +1060,39 @@ class TLSCertificatesProvidesV2(Object):
         for certificate_relation in certificates_relation:
             self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
 
+    def get_issued_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> Dict[str, Dict[str, str]]:
+        """Returns a dictionary of issued certificates.
+
+        It returns certificates from all relations if relation_id is not specified.
+        Certificates are returned per application name and CSR.
+
+        Returns:
+            dict: Certificates per application name.
+        """
+        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+        for relation in relations:
+            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_certificates = provider_relation_data.get("certificates", [])
+            for certificate in provider_certificates:
+                if not certificate.get("revoked", False):
+                    certificates[relation.app.name].update(  # type: ignore[union-attr]
+                        {certificate["certificate_signing_request"]: certificate["certificate"]}
+                    )
+        return certificates
+
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggerred on relation changed event.
+        """Handler triggered on relation changed event.
 
         Looks at the relation data and either emits:
         - certificate request event: If the unit relation data contains a CSR for which
@@ -1070,9 +1110,7 @@ class TLSCertificatesProvidesV2(Object):
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
         provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
         if not self._relation_data_is_valid(requirer_relation_data):
-            logger.warning(
-                f"Relation data did not pass JSON Schema validation: {requirer_relation_data}"
-            )
+            logger.debug("Relation data did not pass JSON Schema validation")
             return
         provider_certificates = provider_relation_data.get("certificates", [])
         requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
@@ -1126,6 +1164,84 @@ class TLSCertificatesProvidesV2(Object):
                 )
                 self.remove_certificate(certificate=certificate["certificate"])
 
+    def get_requirer_csrs_with_no_certs(
+        self,
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Filters the requirer's units csrs.
+
+        Keeps the ones for which no certificate was provided.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            that don't have a certificate issued.
+        """
+        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs())
+        for unit_csr_mapping in all_unit_csr_mappings:
+            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
+                if self.certificate_issued_for_csr(
+                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
+                    csr=csr["certificate_signing_request"],  # type: ignore[index]
+                ):
+                    unit_csr_mapping["unit_csrs"].remove(csr)  # type: ignore[union-attr, arg-type]
+            if len(unit_csr_mapping["unit_csrs"]) == 0:  # type: ignore[arg-type]
+                all_unit_csr_mappings.remove(unit_csr_mapping)
+        return all_unit_csr_mappings
+
+    def get_requirer_csrs(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Returns a list of requirers' CSRs grouped by unit.
+
+        It returns CSRs from all relations if relation_id is not specified.
+        CSRs are returned per relation id, application name and unit name.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            with the following information
+            relation_id, application_name and unit_name.
+        """
+        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
+
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+
+        for relation in relations:
+            for unit in relation.units:
+                requirer_relation_data = _load_relation_data(relation.data[unit])
+                unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
+                unit_csr_mappings.append(
+                    {
+                        "relation_id": relation.id,
+                        "application_name": relation.app.name,  # type: ignore[union-attr]
+                        "unit_name": unit.name,
+                        "unit_csrs": unit_csrs_list,
+                    }
+                )
+        return unit_csr_mappings
+
+    def certificate_issued_for_csr(self, app_name: str, csr: str) -> bool:
+        """Checks whether a certificate has been issued for a given CSR.
+
+        Args:
+            app_name (str): Application name that the CSR belongs to.
+            csr (str): Certificate Signing Request.
+
+        Returns:
+            bool: True/False depending on whether a certificate has been issued for the given CSR.
+        """
+        issued_certificates_per_csr = self.get_issued_certificates()[app_name]
+        for request, cert in issued_certificates_per_csr.items():
+            if request == csr:
+                return csr_matches_certificate(csr, cert)
+        return False
+
 
 class TLSCertificatesRequiresV2(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
@@ -1156,11 +1272,14 @@ class TLSCertificatesRequiresV2(Object):
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
         )
-        self.framework.observe(charm.on.update_status, self._on_update_status)
+        if JujuVersion.from_environ().has_secrets:
+            self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
+        else:
+            self.framework.observe(charm.on.update_status, self._on_update_status)
 
     @property
     def _requirer_csrs(self) -> List[Dict[str, str]]:
-        """Returns list of requirer CSR's from relation data."""
+        """Returns list of requirer's CSRs from relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
@@ -1169,13 +1288,18 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _provider_certificates(self) -> List[Dict[str, str]]:
-        """Returns list of provider CSRs from relation data."""
+        """Returns list of certificates from the provider's relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+            logger.debug("No relation: %s", self.relationship_name)
+            return []
         if not relation.app:
-            raise RuntimeError(f"Remote app for relation {self.relationship_name} does not exist")
+            logger.debug("No remote app in relation: %s", self.relationship_name)
+            return []
         provider_relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(provider_relation_data):
+            logger.warning("Provider relation data did not pass JSON Schema validation")
+            return []
         return provider_relation_data.get("certificates", [])
 
     def _add_requirer_csr(self, csr: str) -> None:
@@ -1235,12 +1359,10 @@ class TLSCertificatesRequiresV2(Object):
         """
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            message = (
+            raise RuntimeError(
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-            logger.error(message)
-            raise RuntimeError(message)
         self._add_requirer_csr(certificate_signing_request.decode().strip())
         logger.info("Certificate request sent to provider")
 
@@ -1304,26 +1426,21 @@ class TLSCertificatesRequiresV2(Object):
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handler triggered on relation changed events.
 
+        Goes through all providers certificates that match a requested CSR.
+
+        If the provider certificate is revoked, emit a CertificateInvalidateEvent,
+        otherwise emit a CertificateAvailableEvent.
+
+        When Juju secrets are available, remove the secret for revoked certificate,
+        or add a secret with the correct expiry time for new certificates.
+
+
         Args:
             event: Juju event
 
         Returns:
             None
         """
-        relation = self.model.get_relation(self.relationship_name)
-        if not relation:
-            logger.warning(f"No relation: {self.relationship_name}")
-            return
-        if not relation.app:
-            logger.warning(f"No remote app in relation: {self.relationship_name}")
-            return
-        provider_relation_data = _load_relation_data(relation.data[relation.app])
-        if not self._relation_data_is_valid(provider_relation_data):
-            logger.warning(
-                f"Provider relation data did not pass JSON Schema validation: "
-                f"{event.relation.data[relation.app]}"
-            )
-            return
         requirer_csrs = [
             certificate_creation_request["certificate_signing_request"]
             for certificate_creation_request in self._requirer_csrs
@@ -1331,6 +1448,12 @@ class TLSCertificatesRequiresV2(Object):
         for certificate in self._provider_certificates:
             if certificate["certificate_signing_request"] in requirer_csrs:
                 if certificate.get("revoked", False):
+                    if JujuVersion.from_environ().has_secrets:
+                        with suppress(SecretNotFoundError):
+                            secret = self.model.get_secret(
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
+                            )
+                            secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",
                         certificate=certificate["certificate"],
@@ -1339,12 +1462,51 @@ class TLSCertificatesRequiresV2(Object):
                         chain=certificate["chain"],
                     )
                 else:
+                    if JujuVersion.from_environ().has_secrets:
+                        try:
+                            secret = self.model.get_secret(
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
+                            )
+                            secret.set_content({"certificate": certificate["certificate"]})
+                            secret.set_info(
+                                expire=self._get_next_secret_expiry_time(
+                                    certificate["certificate"]
+                                ),
+                            )
+                        except SecretNotFoundError:
+                            secret = self.charm.unit.add_secret(
+                                {"certificate": certificate["certificate"]},
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}",
+                                expire=self._get_next_secret_expiry_time(
+                                    certificate["certificate"]
+                                ),
+                            )
                     self.on.certificate_available.emit(
                         certificate_signing_request=certificate["certificate_signing_request"],
                         certificate=certificate["certificate"],
                         ca=certificate["ca"],
                         chain=certificate["chain"],
                     )
+
+    def _get_next_secret_expiry_time(self, certificate: str) -> Optional[datetime]:
+        """Return the expiry time or expiry notification time.
+
+        Extracts the expiry time from the provided certificate, calculates the
+        expiry notification time and return the closest of the two, that is in
+        the future.
+
+        Args:
+            certificate: x509 certificate
+
+        Returns:
+            Optional[datetime]: None if the certificate expiry time cannot be read,
+                                next expiry time otherwise.
+        """
+        expiry_time = _get_certificate_expiry_time(certificate)
+        if not expiry_time:
+            return None
+        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
+        return _get_closest_future_time(expiry_notification_time, expiry_time)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handler triggered on relation broken event.
@@ -1358,12 +1520,67 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
-        relation = self.model.get_relation(self.relationship_name)
-        if not relation:
-            return
-        if not relation.data[relation.app].get("certificates"):  # type: ignore[index]
-            return
         self.on.all_certificates_invalidated.emit()
+
+    def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
+        """Triggered when a certificate is set to expire.
+
+        Loads the certificate from the secret, and will emit 1 of 2
+        events.
+
+        If the certificate is not yet expired, emits CertificateExpiringEvent
+        and updates the expiry time of the secret to the exact expiry time on
+        the certificate.
+
+        If the certificate is expired, emits CertificateInvalidedEvent and
+        deletes the secret.
+
+        Args:
+            event (SecretExpiredEvent): Juju event
+        """
+        if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
+            return
+        csr = event.secret.label[len(f"{LIBID}-") :]
+        certificate_dict = self._find_certificate_in_relation_data(csr)
+        if not certificate_dict:
+            # A secret expired but we did not find matching certificate. Cleaning up
+            event.secret.remove_all_revisions()
+            return
+
+        expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
+        if not expiry_time:
+            # A secret expired but matching certificate is invalid. Cleaning up
+            event.secret.remove_all_revisions()
+            return
+
+        if datetime.utcnow() < expiry_time:
+            logger.warning("Certificate almost expired")
+            self.on.certificate_expiring.emit(
+                certificate=certificate_dict["certificate"],
+                expiry=expiry_time.isoformat(),
+            )
+            event.secret.set_info(
+                expire=_get_certificate_expiry_time(certificate_dict["certificate"]),
+            )
+        else:
+            logger.warning("Certificate is expired")
+            self.on.certificate_invalidated.emit(
+                reason="expired",
+                certificate=certificate_dict["certificate"],
+                certificate_signing_request=certificate_dict["certificate_signing_request"],
+                ca=certificate_dict["ca"],
+                chain=certificate_dict["chain"],
+            )
+            self.request_certificate_revocation(certificate_dict["certificate"].encode())
+            event.secret.remove_all_revisions()
+
+    def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
+        """Returns the certificate that match the given CSR."""
+        for certificate_dict in self._provider_certificates:
+            if certificate_dict["certificate_signing_request"] != csr:
+                continue
+            return certificate_dict
+        return None
 
     def _on_update_status(self, event: UpdateStatusEvent) -> None:
         """Triggered on update status event.
@@ -1378,29 +1595,11 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
-        relation = self.model.get_relation(self.relationship_name)
-        if not relation:
-            logger.warning(f"No relation: {self.relationship_name}")
-            return
-        if not relation.app:
-            logger.warning(f"No remote app in relation: {self.relationship_name}")
-            return
-        provider_relation_data = _load_relation_data(relation.data[relation.app])
-        if not self._relation_data_is_valid(provider_relation_data):
-            logger.warning(
-                f"Provider relation data did not pass JSON Schema validation: "
-                f"{relation.data[relation.app]}"
-            )
-            return
         for certificate_dict in self._provider_certificates:
-            try:
-                certificate_object = x509.load_pem_x509_certificate(
-                    data=certificate_dict["certificate"].encode()
-                )
-            except ValueError:
-                logger.warning("Could not load certificate.")
+            expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
+            if not expiry_time:
                 continue
-            time_difference = certificate_object.not_valid_after - datetime.utcnow()
+            time_difference = expiry_time - datetime.utcnow()
             if time_difference.total_seconds() < 0:
                 logger.warning("Certificate is expired")
                 self.on.certificate_invalidated.emit(
@@ -1416,5 +1615,70 @@ class TLSCertificatesRequiresV2(Object):
                 logger.warning("Certificate almost expired")
                 self.on.certificate_expiring.emit(
                     certificate=certificate_dict["certificate"],
-                    expiry=certificate_object.not_valid_after.isoformat(),
+                    expiry=expiry_time.isoformat(),
                 )
+
+
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    expects to get the original string representations.
+
+    Args:
+        csr (str): Certificate Signing Request
+        cert (str): Certificate
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if csr_object.subject != cert_object.subject:
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
+
+
+def _get_closest_future_time(
+    expiry_notification_time: datetime, expiry_time: datetime
+) -> datetime:
+    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
+
+    Args:
+        expiry_notification_time (datetime): Notification time of impending expiration
+        expiry_time (datetime): Expiration time
+
+    Returns:
+        datetime: expiry_notification_time if not in the past, expiry_time otherwise
+    """
+    return (
+        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
+    )
+
+
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+    """Extract expiry time from a certificate string.
+
+    Args:
+        certificate (str): x509 certificate as a string
+
+    Returns:
+        Optional[datetime]: Expiry datetime or None
+    """
+    try:
+        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+        return certificate_object.not_valid_after
+    except ValueError:
+        logger.warning("Could not load certificate.")
+        return None

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,7 +276,6 @@ import copy
 import json
 import logging
 import uuid
-from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
@@ -299,7 +298,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import SecretNotFoundError
+from ops.model import Relation, SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
@@ -309,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 16
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -641,6 +640,17 @@ def generate_ca(
         private_key_object.public_key()  # type: ignore[arg-type]
     )
     subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -658,6 +668,7 @@ def generate_ca(
             ),
             critical=False,
         )
+        .add_extension(key_usage, critical=True)
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=None),
             critical=True,
@@ -690,7 +701,8 @@ def generate_certificate(
     """
     csr_object = x509.load_pem_x509_csr(csr)
     subject = csr_object.subject
-    issuer = x509.load_pem_x509_certificate(ca).issuer
+    ca_pem = x509.load_pem_x509_certificate(ca)
+    issuer = ca_pem.issuer
     private_key = serialization.load_pem_private_key(ca_key, password=ca_key_password)
 
     certificate_builder = (
@@ -701,6 +713,20 @@ def generate_certificate(
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.utcnow())
         .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=ca_pem.extensions.get_extension_for_class(
+                    x509.SubjectKeyIdentifier
+                ).value.key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(csr_object.public_key()), critical=False
+        )
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=False)
     )
 
     extensions_list = csr_object.extensions
@@ -731,6 +757,7 @@ def generate_certificate(
             extension.value,
             critical=extension.critical,
         )
+
     certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
     return cert.public_bytes(serialization.Encoding.PEM)
@@ -828,7 +855,7 @@ def generate_csr(
         sans_oid (list): List of registered ID SANs
         sans_dns (list): List of DNS subject alternative names (similar to the arg: sans)
         sans_ip (list): List of IP subject alternative names
-        additional_critical_extensions (list): List if critical additional extension objects.
+        additional_critical_extensions (list): List of critical additional extension objects.
             Object must be a x509 ExtensionType.
 
     Returns:
@@ -898,6 +925,22 @@ class TLSCertificatesProvidesV2(Object):
         self.charm = charm
         self.relationship_name = relationship_name
 
+    def _load_app_relation_data(self, relation: Relation) -> dict:
+        """Loads relation data from the application relation data bag.
+
+        Json loads all data.
+
+        Args:
+            relation_object: Relation data from the application databag
+
+        Returns:
+            dict: Relation data in dict format.
+        """
+        # If unit is not leader, it does not try to reach relation data.
+        if not self.model.unit.is_leader():
+            return {}
+        return _load_relation_data(relation.data[self.charm.app])
+
     def _add_certificate(
         self,
         relation_id: int,
@@ -932,7 +975,7 @@ class TLSCertificatesProvidesV2(Object):
             "ca": ca,
             "chain": chain,
         }
-        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         if new_certificate in certificates:
@@ -965,7 +1008,7 @@ class TLSCertificatesProvidesV2(Object):
             raise RuntimeError(
                 f"Relation {self.relationship_name} with relation id {relation_id} does not exist"
             )
-        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         for certificate_dict in certificates:
@@ -1000,7 +1043,7 @@ class TLSCertificatesProvidesV2(Object):
         This method is meant to be used when the Root CA has changed.
         """
         for relation in self.model.relations[self.relationship_name]:
-            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = copy.deepcopy(provider_relation_data.get("certificates", []))
             for certificate in provider_certificates:
                 certificate["revoked"] = True
@@ -1062,7 +1105,7 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, Dict[str, str]]:
+    ) -> Dict[str, List[Dict[str, str]]]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1071,7 +1114,7 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        certificates: Dict[str, List[Dict[str, str]]] = {}
         relations = (
             [
                 relation
@@ -1082,13 +1125,19 @@ class TLSCertificatesProvidesV2(Object):
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
-            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = provider_relation_data.get("certificates", [])
+
+            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
                 if not certificate.get("revoked", False):
-                    certificates[relation.app.name].update(  # type: ignore[union-attr]
-                        {certificate["certificate_signing_request"]: certificate["certificate"]}
+                    certificates[relation.app.name].append(  # type: ignore[union-attr]
+                        {
+                            "csr": certificate["certificate_signing_request"],
+                            "certificate": certificate["certificate"],
+                        }
                     )
+
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1106,9 +1155,13 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             None
         """
-        assert event.unit is not None
+        if event.unit is None:
+            logger.error("Relation_changed event does not have a unit.")
+            return
+        if not self.model.unit.is_leader():
+            return
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
-        provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(event.relation)
         if not self._relation_data_is_valid(requirer_relation_data):
             logger.debug("Relation data did not pass JSON Schema validation")
             return
@@ -1147,7 +1200,7 @@ class TLSCertificatesProvidesV2(Object):
         )
         if not certificates_relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
-        provider_relation_data = _load_relation_data(certificates_relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(certificates_relation)
         list_of_csrs: List[str] = []
         for unit in certificates_relation.units:
             requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
@@ -1165,27 +1218,33 @@ class TLSCertificatesProvidesV2(Object):
                 self.remove_certificate(certificate=certificate["certificate"])
 
     def get_requirer_csrs_with_no_certs(
-        self,
+        self, relation_id: Optional[int] = None
     ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
         """Filters the requirer's units csrs.
 
         Keeps the ones for which no certificate was provided.
 
+        Args:
+            relation_id (int): Relation id
+
         Returns:
             list: List of dictionaries that contain the unit's csrs
             that don't have a certificate issued.
         """
-        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs())
+        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs(relation_id=relation_id))
+        filtered_all_unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
         for unit_csr_mapping in all_unit_csr_mappings:
+            csrs_without_certs = []
             for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
-                if self.certificate_issued_for_csr(
+                if not self.certificate_issued_for_csr(
                     app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
                     csr=csr["certificate_signing_request"],  # type: ignore[index]
                 ):
-                    unit_csr_mapping["unit_csrs"].remove(csr)  # type: ignore[union-attr, arg-type]
-            if len(unit_csr_mapping["unit_csrs"]) == 0:  # type: ignore[arg-type]
-                all_unit_csr_mappings.remove(unit_csr_mapping)
-        return all_unit_csr_mappings
+                    csrs_without_certs.append(csr)
+            if csrs_without_certs:
+                unit_csr_mapping["unit_csrs"] = csrs_without_certs  # type: ignore[assignment]
+                filtered_all_unit_csr_mappings.append(unit_csr_mapping)
+        return filtered_all_unit_csr_mappings
 
     def get_requirer_csrs(
         self, relation_id: Optional[int] = None
@@ -1237,9 +1296,9 @@ class TLSCertificatesProvidesV2(Object):
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """
         issued_certificates_per_csr = self.get_issued_certificates()[app_name]
-        for request, cert in issued_certificates_per_csr.items():
-            if request == csr:
-                return csr_matches_certificate(csr, cert)
+        for issued_pair in issued_certificates_per_csr:
+            if "csr" in issued_pair and issued_pair["csr"] == csr:
+                return csr_matches_certificate(csr, issued_pair["certificate"])
         return False
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -173,8 +173,8 @@ class TLSRequirerOperatorCharm(CharmBase):
         self._revoke_existing_certificates()
         self._generate_csr()
         if not self._csr_is_stored:
-            # This check is required because of a race condition.
-            # If _request_certificate is called and storing csr is still in process, RuntimeError happens.  # noqa: E501, W505
+            # This check is required because of a Juju bug: https://bugs.launchpad.net/juju/+bug/2034050  # noqa: E501, W505
+            # If _request_certificate is called and stored CSR could not be found, RuntimeError happens.  # noqa: E501, W505
             self.unit.status = WaitingStatus("Waiting csr to be stored.")
             event.defer()
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,7 +204,6 @@ class TLSRequirerOperatorCharm(CharmBase):
         signing request (CSR) and inserts it into the `certificates` relation unit relation data.
         """
         if not self._csr_is_stored:
-            self.unit.status = WaitingStatus("Waiting for CSR to be generated.")
             return
         csr_secret = self.model.get_secret(label=CSR_SECRET_LABEL)
         csr_secret_content = csr_secret.get_content()

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,7 +204,8 @@ class TLSRequirerOperatorCharm(CharmBase):
         signing request (CSR) and inserts it into the `certificates` relation unit relation data.
         """
         if not self._csr_is_stored:
-            raise RuntimeError("CSR is not stored")
+            self.unit.status = WaitingStatus("Waiting for CSR to be generated.")
+            return
         csr_secret = self.model.get_secret(label=CSR_SECRET_LABEL)
         csr_secret_content = csr_secret.get_content()
         self.certificates.request_certificate_creation(

--- a/src/charm.py
+++ b/src/charm.py
@@ -172,12 +172,6 @@ class TLSRequirerOperatorCharm(CharmBase):
 
         self._revoke_existing_certificates()
         self._generate_csr()
-        if not self._csr_is_stored:
-            # This check is required because of a Juju bug: https://bugs.launchpad.net/juju/+bug/2034050  # noqa: E501, W505
-            # If _request_certificate is called and stored CSR could not be found, RuntimeError happens.  # noqa: E501, W505
-            self.unit.status = WaitingStatus("Waiting csr to be stored.")
-            event.defer()
-            return
         self._request_certificate()
         self.unit.status = WaitingStatus("Waiting for certificate to be available.")
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju>=3.0
+juju==3.1.6  # As it requires this fix https://github.com/juju/juju/pull/16204
 mypy
 pep8-naming
 pyproject-flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju>=3.1.6  # As it requires this fix https://github.com/juju/juju/pull/16204
+juju>=3.1.6  # Requires https://github.com/juju/juju/pull/16204
 mypy
 pep8-naming
 pyproject-flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju>=3.1.6  # Requires https://github.com/juju/juju/pull/16204
+juju>=3.1.6
 mypy
 pep8-naming
 pyproject-flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju==3.1.6  # As it requires this fix https://github.com/juju/juju/pull/16204
+juju>=3.1.6  # As it requires this fix https://github.com/juju/juju/pull/16204
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def build_and_deploy(ops_test):
+async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(
@@ -31,7 +32,7 @@ async def build_and_deploy(ops_test):
 
 @pytest.mark.abort_on_fail
 async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
-    ops_test,
+    ops_test: OpsTest,
     build_and_deploy,
 ):
     await ops_test.model.wait_for_idle(
@@ -42,7 +43,7 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
 
 
 async def test_given_self_signed_certificates_is_deployed_and_related_then_status_is_active(  # noqa: E501
-    ops_test,
+    ops_test: OpsTest,
     build_and_deploy,
 ):
     await ops_test.model.deploy(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -58,10 +58,6 @@ async def test_given_self_signed_certificates_is_deployed_and_related_then_statu
     await ops_test.model.add_relation(
         relation1=f"{SELF_SIGNED_CERTIFICATES_CHARM_NAME}:certificates", relation2=f"{APP_NAME}"
     )
-    tls_requirer_unit = ops_test.model.units[f"{APP_NAME}/0"]
-    await tls_requirer_unit.run_action(
-        action_name="get-certificate",
-    )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         status="active",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -42,7 +42,7 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
     )
 
 
-async def test_given_self_signed_certificates_is_deployed_and_related_then_status_is_active(  # noqa: E501
+async def test_given_self_signed_certificates_is_related_when_deployed_then_status_is_active(  # noqa: E501
     ops_test: OpsTest,
     build_and_deploy,
 ):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -22,7 +22,7 @@ SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         charm,
         application_name=APP_NAME,
         series="jammy",
@@ -35,7 +35,7 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
     ops_test: OpsTest,
     build_and_deploy,
 ):
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APP_NAME],
         status="blocked",
         timeout=1000,
@@ -46,20 +46,20 @@ async def test_given_self_signed_certificates_is_related_when_deployed_then_stat
     ops_test: OpsTest,
     build_and_deploy,
 ):
-    await ops_test.model.deploy(
+    await ops_test.model.deploy(  # type: ignore[union-attr]
         SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         channel="edge",
     )
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[SELF_SIGNED_CERTIFICATES_CHARM_NAME],
         status="active",
         timeout=1000,
     )
-    await ops_test.model.add_relation(
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{SELF_SIGNED_CERTIFICATES_CHARM_NAME}:certificates", relation2=f"{APP_NAME}"
     )
-    await ops_test.model.wait_for_idle(
+    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APP_NAME],
         status="active",
         timeout=1000,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from ops import testing
-from ops.model import BlockedStatus, SecretNotFoundError, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
 from charm import TLSRequirerOperatorCharm
 
@@ -228,6 +228,26 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             secret["csr"],
             CSR,
+        )
+
+    def test_given_csrs_match_when_on_certificate_available_then_status_is_active(self):
+        certificate = "whatever certificate"
+        ca = "whatever ca"
+        chain = ["whatever cert 1", "whatever cert 2"]
+        self.harness.set_leader(is_leader=True)
+        self.harness._backend.secret_add(label="csr", content={"csr": CSR})
+
+        self.harness.charm._on_certificate_available(
+            event=Mock(
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                certificate_signing_request=CSR,
+            )
+        )
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus(),
         )
 
     def test_given_certificate_already_stored_when_on_certificate_available_then_certificate_is_overwritten(  # noqa: E501

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -86,6 +86,20 @@ class TestCharm(unittest.TestCase):
 
         patch_request_certificate.assert_called_with(certificate_signing_request=csr.encode())
 
+    @patch(
+        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation"  # noqa: E501, W505
+    )
+    @patch("charm.generate_csr")
+    def test_given_csr_is_not_generated_and_certificate_relation_is_created_then_request_certificate_is_not_called(  # noqa: E501
+        self,
+        patch_generate_csr,
+        patch_request_certificate,
+    ):
+        self.harness.set_leader(is_leader=True)
+        patch_generate_csr.side_effect = RuntimeError("Private key not stored.")
+        self.harness.add_relation(relation_name="certificates", remote_app="certificates-provider")
+        patch_request_certificate.assert_not_called()
+
     @patch("charm.generate_csr")
     def test_given_certificate_is_requested_when_on_config_changed_then_status_is_waiting(
         self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -86,20 +86,6 @@ class TestCharm(unittest.TestCase):
 
         patch_request_certificate.assert_called_with(certificate_signing_request=csr.encode())
 
-    @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation"  # noqa: E501, W505
-    )
-    @patch("charm.generate_csr")
-    def test_given_csr_is_not_generated_and_certificate_relation_is_created_then_request_certificate_is_not_called(  # noqa: E501
-        self,
-        patch_generate_csr,
-        patch_request_certificate,
-    ):
-        self.harness.set_leader(is_leader=True)
-        patch_generate_csr.side_effect = RuntimeError("Private key not stored.")
-        self.harness.add_relation(relation_name="certificates", remote_app="certificates-provider")
-        patch_request_certificate.assert_not_called()
-
     @patch("charm.generate_csr")
     def test_given_certificate_is_requested_when_on_config_changed_then_status_is_waiting(
         self,
@@ -348,3 +334,9 @@ class TestCharm(unittest.TestCase):
 
         with pytest.raises(SecretNotFoundError):
             self.harness._backend.secret_get(label="certificate")
+
+    def test_given_csr_is_not_stored_when_request_certificate_called_then_runtime_error_is_not_raised(  # noqa: E501
+        self,
+    ):
+        self.assertEqual(self.harness.charm._secret_exists(label="csr"), False)
+        self.harness.charm._request_certificate()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit
+envlist = lint, unit, static
 
 [vars]
 src_path = {toxinidir}/src/


### PR DESCRIPTION
# Description

If relation created immediately before CSR generated, RuntimeError happens when we request certificate creation. 
Certificate creation request needs to wait for CSR generation first. Aiming to solve following issue: https://github.com/canonical/tls-certificates-requirer-operator/issues/13
tls_certificate_interface library version is updated to 10.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
