### PR TITLE
feat: Implements per-unit certificate requests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,0 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-options:
-  subject:
-    type: string
-    default: tls-requirer-operator
-    description: Common name to be used.

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -287,7 +287,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
 from cryptography.x509.extensions import Extension, ExtensionNotFound
-from jsonschema import exceptions, validate  # type: ignore[import]
+from jsonschema import exceptions, validate  # type: ignore[import-untyped]
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 18
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1701,7 +1701,10 @@ def csr_matches_certificate(csr: str, cert: str) -> bool:
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         ):
             return False
-        if csr_object.subject != cert_object.subject:
+        if (
+            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
+            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
+        ):
             return False
     except ValueError:
         logger.warning("Could not load certificate or CSR.")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import time
 from pathlib import Path
 
 import pytest
@@ -16,29 +17,54 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 
+NUM_UNITS = 3
+
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
+    assert ops_test.model
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    await ops_test.model.deploy(
         charm,
         application_name=APP_NAME,
         series="jammy",
         trust=True,
-        num_units=3,
+        num_units=NUM_UNITS,
     )
 
 
+async def wait_for_certificate_available(ops_test: OpsTest, unit_name: str) -> dict:
+    """Runs the `get-certificate` action until it returns a certificate.
+
+    If the action does not return a certificate within 60 seconds, a TimeoutError is raised.
+    """
+    assert ops_test.model
+    start_time = time.time()
+    while time.time() - start_time < 60:
+        tls_requirer_unit = ops_test.model.units[unit_name]
+        action = await tls_requirer_unit.run_action(action_name="get-certificate")
+        action_output = await ops_test.model.get_action_output(
+            action_uuid=action.entity_id,
+            wait=30,
+        )
+        logger.info("Action output: %s", action_output)
+        if action_output["return-code"] == 0:
+            return action_output
+        time.sleep(1)
+    raise TimeoutError("Timed out waiting for certificate")
+
+
 @pytest.mark.abort_on_fail
-async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
+async def test_given_charm_is_built_when_deployed_then_status_is_active(
     ops_test: OpsTest,
     build_and_deploy,
 ):
-    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
-        status="blocked",
+        status="active",
         timeout=1000,
     )
 
@@ -47,21 +73,37 @@ async def test_given_self_signed_certificates_is_related_when_deployed_then_stat
     ops_test: OpsTest,
     build_and_deploy,
 ):
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         channel="edge",
     )
-    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
+    await ops_test.model.wait_for_idle(
         apps=[SELF_SIGNED_CERTIFICATES_CHARM_NAME],
         status="active",
         timeout=1000,
     )
-    await ops_test.model.add_relation(  # type: ignore[union-attr]
+    await ops_test.model.integrate(
         relation1=f"{SELF_SIGNED_CERTIFICATES_CHARM_NAME}:certificates", relation2=f"{APP_NAME}"
     )
-    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
+    await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         status="active",
         timeout=1000,
     )
+
+
+async def test_given_self_signed_certificates_is_related_when_get_certificate_action_then_certificate_is_returned(  # noqa: E501
+    ops_test,
+    build_and_deploy,
+):
+    for unit in range(NUM_UNITS):
+        action_output = await wait_for_certificate_available(
+            ops_test=ops_test, unit_name=f"{APP_NAME}/{unit}"
+        )
+
+        assert action_output["certificate"] is not None
+        assert action_output["ca-certificate"] is not None
+        assert action_output["chain"] is not None
+        assert action_output["csr"] is not None

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,6 +27,7 @@ async def build_and_deploy(ops_test: OpsTest):
         application_name=APP_NAME,
         series="jammy",
         trust=True,
+        num_units=3,
     )
 
 


### PR DESCRIPTION
# Description

Each unit generates its own private key and CSR and receives its own certificate. This makes it possible to scale this charm to an arbitrary number of units.

Fixes #22 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
