### PR TITLE
fix: Generates csr and requests cert only if the unit does not have them

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -126,9 +126,13 @@ class TLSRequirerOperatorCharm(CharmBase):
         Args:
             event: Juju event.
         """
-        self._generate_csr(common_name=self._get_unit_common_name())
-        self._request_certificate()
-        self.unit.status = ActiveStatus("Certificate request is sent")
+        if not self._csr_is_stored:
+            self._generate_csr(common_name=self._get_unit_common_name())
+        if not self._certificate_is_stored:
+            self._request_certificate()
+            self.unit.status = ActiveStatus("Certificate request is sent")
+        else:
+            self.unit.status = ActiveStatus("Certificate is available")
 
     def _get_unit_common_name(self) -> str:
         return f"{self.app.name}-{self._get_unit_number()}.{self.model.name}"
@@ -168,11 +172,7 @@ class TLSRequirerOperatorCharm(CharmBase):
             subject=common_name,
         )
         csr_secret_content = {"csr": csr.decode()}
-        if self._csr_is_stored:
-            csr_secret = self.model.get_secret(label=self._get_csr_secret_label())
-            csr_secret.set_content(content=csr_secret_content)
-        else:
-            self.unit.add_secret(content=csr_secret_content, label=self._get_csr_secret_label())
+        self.unit.add_secret(content=csr_secret_content, label=self._get_csr_secret_label())
 
     @property
     def _private_key_is_stored(self) -> bool:

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,8 +131,6 @@ class TLSRequirerOperatorCharm(CharmBase):
         if not self._certificate_is_stored:
             self._request_certificate()
             self.unit.status = ActiveStatus("Certificate request is sent")
-        else:
-            self.unit.status = ActiveStatus("Certificate is available")
 
     def _get_unit_common_name(self) -> str:
         return f"{self.app.name}-{self._get_unit_number()}.{self.model.name}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -260,20 +260,23 @@ class TestCharm(unittest.TestCase):
         patch_request_certificate_creation,
     ):
         self.harness.set_leader(is_leader=True)
+        chain = ["whatever cert 1", "whatever cert 2"]
         self.harness._backend.secret_add(label="csr-0", content={"csr": CSR})
-        self.harness._backend.secret_add(
-            label="certificate-0",
-            content={
-                "certificate": "whatever",
-                "ca-certificate": CA,
-                "chain": "whatever chain",
-            },
+
+        relation_id = self.harness.add_relation(
+            relation_name="certificates", remote_app="certificates-provider"
+        )
+
+        self.harness.charm._on_certificate_available(
+            event=Mock(
+                certificate=CERTIFICATE,
+                ca=CA,
+                chain=chain,
+                certificate_signing_request=CSR,
+            )
         )
         self.add_secret_for_private_key(
             private_key=PRIVATE_KEY, private_key_password=PRIVATE_KEY_PASSWORD
-        )
-        relation_id = self.harness.add_relation(
-            relation_name="certificates", remote_app="certificates-provider"
         )
 
         self.harness.add_relation_unit(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -62,9 +62,8 @@ class TestCharm(unittest.TestCase):
     ):
         patch_generate_csr.return_value = CSR.encode()
         self.harness.set_leader(is_leader=True)
-        self.harness._backend.secret_add(
-            label="private-key-0",
-            content={"private-key": PRIVATE_KEY, "private-key-password": PRIVATE_KEY_PASSWORD},
+        self.add_secret_for_private_key(
+            private_key=PRIVATE_KEY, private_key_password=PRIVATE_KEY_PASSWORD
         )
         relation_id = self.harness.add_relation(
             relation_name="certificates", remote_app="certificates-provider"
@@ -84,9 +83,8 @@ class TestCharm(unittest.TestCase):
     ):
         patch_generate_csr.return_value = CSR.encode()
         self.harness.set_leader(is_leader=True)
-        self.harness._backend.secret_add(
-            label="private-key-0",
-            content={"private-key": PRIVATE_KEY, "private-key-password": PRIVATE_KEY_PASSWORD},
+        self.add_secret_for_private_key(
+            private_key=PRIVATE_KEY, private_key_password=PRIVATE_KEY_PASSWORD
         )
         relation_id = self.harness.add_relation(
             relation_name="certificates", remote_app="certificates-provider"
@@ -233,3 +231,57 @@ class TestCharm(unittest.TestCase):
 
         with pytest.raises(SecretNotFoundError):
             self.harness._backend.secret_get(label="certificate-0")
+
+    @patch("charm.generate_csr")
+    def test_given_csr_stored_when_relation_joined_then_csr_not_generated_again(
+        self, patch_generate_csr
+    ):
+        self.harness.set_leader(is_leader=True)
+        self.harness._backend.secret_add(label="csr-0", content={"csr": CSR})
+        self.add_secret_for_private_key(
+            private_key=PRIVATE_KEY, private_key_password=PRIVATE_KEY_PASSWORD
+        )
+        relation_id = self.harness.add_relation(
+            relation_name="certificates", remote_app="certificates-provider"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="certificates-provider/0"
+        )
+
+        self.assertEqual(self.harness._backend.secret_get(label="csr-0")["csr"], CSR)
+        patch_generate_csr.assert_not_called()
+
+    @patch(
+        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation"  # noqa: E501, W505
+    )
+    def test_given_certificate_stored_when_relation_joined_then_certificate_not_requested_again(
+        self,
+        patch_request_certificate_creation,
+    ):
+        self.harness.set_leader(is_leader=True)
+        self.harness._backend.secret_add(label="csr-0", content={"csr": CSR})
+        self.harness._backend.secret_add(
+            label="certificate-0",
+            content={
+                "certificate": "whatever",
+                "ca-certificate": CA,
+                "chain": "whatever chain",
+            },
+        )
+        self.add_secret_for_private_key(
+            private_key=PRIVATE_KEY, private_key_password=PRIVATE_KEY_PASSWORD
+        )
+        relation_id = self.harness.add_relation(
+            relation_name="certificates", remote_app="certificates-provider"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="certificates-provider/0"
+        )
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus("Certificate is available"),
+        )
+        patch_request_certificate_creation.assert_not_called()


### PR DESCRIPTION
# Description

The operator now generates a csr and requests certificates in all units every time a new unit joins the relation. 
To avoid this behavior we prevent generating a new csr for the unit or requesting a new certificate if those are present for the unit.
With this solution, the operator can't have multiple csrs and certs per unit.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
