### PR TITLE
feat: Adds common_name juju config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+options:
+  common_name:
+    type: string
+    description: |
+      Common name to be used in the certificate. If not set, the common name will be <app name>-<unit number>.<model name>

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,6 +133,14 @@ class TLSRequirerOperatorCharm(CharmBase):
             self.unit.status = ActiveStatus("Certificate request is sent")
 
     def _get_unit_common_name(self) -> str:
+        """Returns common name for the unit.
+
+        If `common_name` config option is set, it will be used as a common name.
+        Otherwise, the common name will be generated based on the application name and unit number.
+        """
+        config_common_name = self.model.config.get("common_name")
+        if config_common_name:
+            return config_common_name
         return f"{self.app.name}-{self._get_unit_number()}.{self.model.name}"
 
     def _revoke_existing_certificates(self) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,8 +21,10 @@ CERTIFICATE = "whatever certificate"
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
+        self.model_name = "whatever"
         self.harness = testing.Harness(TLSRequirerOperatorCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(self.model_name)
         self.harness.begin()
 
     def _add_model_secret(self, owner: str, content: dict, label: str) -> None:
@@ -83,9 +85,48 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(
             relation_id=relation_id, remote_unit_name="certificates-provider/0"
         )
-
+        unit_number = self.harness.model.unit.name.split("/")[1]
+        patch_generate_csr.assert_called_with(
+            private_key=PRIVATE_KEY.encode(),
+            private_key_password=PRIVATE_KEY_PASSWORD.encode(),
+            subject=f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}",
+        )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()
+        )
+
+    @patch("charm.generate_csr")
+    @patch(
+        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation"  # noqa: E501, W505
+    )
+    def test_given_common_name_config_is_set_when_certificates_relation_joined_then_certificate_is_requested(  # noqa: E501
+        self,
+        _,
+        patch_generate_csr,
+    ):
+        self.harness.update_config({"common_name": SUBJECT})
+        patch_generate_csr.return_value = CSR.encode()
+        self.harness.set_leader(is_leader=True)
+        self._add_model_secret(
+            owner=self.harness.model.unit.name,
+            content={
+                "private-key": PRIVATE_KEY,
+                "private-key-password": PRIVATE_KEY_PASSWORD,
+            },
+            label="private-key-0",
+        )
+        relation_id = self.harness.add_relation(
+            relation_name="certificates", remote_app="certificates-provider"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="certificates-provider/0"
+        )
+
+        patch_generate_csr.assert_called_with(
+            private_key=PRIVATE_KEY.encode(),
+            private_key_password=PRIVATE_KEY_PASSWORD.encode(),
+            subject=SUBJECT,
         )
 
     @patch("charm.generate_csr")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -99,9 +99,9 @@ class TestCharm(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation"  # noqa: E501, W505
     )
-    def test_given_common_name_config_is_set_when_certificates_relation_joined_then_certificate_is_requested(  # noqa: E501
+    def test_given_common_name_config_is_set_when_certificates_relation_joined_then_certificate_is_requested_with_common_name(  # noqa: E501
         self,
-        _,
+        patch_request_certificate_creation,
         patch_generate_csr,
     ):
         self.harness.update_config({"common_name": SUBJECT})
@@ -127,6 +127,9 @@ class TestCharm(unittest.TestCase):
             private_key=PRIVATE_KEY.encode(),
             private_key_password=PRIVATE_KEY_PASSWORD.encode(),
             subject=SUBJECT,
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=CSR.encode()
         )
 
     @patch("charm.generate_csr")


### PR DESCRIPTION
# Description

It was currently not possible to run this charm as a requirer of one of the LEGO charms as a TLS provider because the CSR generated by the tls-certificates requirer had a common name set to be `<app name>-<unit number>.<model name>`. This PR makes the common name configurable, making it possible to get certs from any Let's Encrypt charm provider.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
