### PR TITLE
fix: Does not store ca chain

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -106,7 +106,6 @@ class TLSRequirerOperatorCharm(CharmBase):
         certificate_secret_content = {
             "certificate": event.certificate,
             "ca-certificate": event.ca,
-            "chain": json.dumps(event.chain),
             "csr": event.certificate_signing_request,
         }
         if self._certificate_is_stored:
@@ -235,7 +234,6 @@ class TLSRequirerOperatorCharm(CharmBase):
                 {
                     "certificate": content["certificate"],
                     "ca-certificate": content["ca-certificate"],
-                    "chain": json.loads(content["chain"]),
                     "csr": content["csr"],
                 }
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,6 @@
 
 """Charm that requests X.509 certificates using the tls-certificates interface."""
 
-import json
 import logging
 import secrets
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -105,5 +105,4 @@ async def test_given_self_signed_certificates_is_related_when_get_certificate_ac
 
         assert action_output["certificate"] is not None
         assert action_output["ca-certificate"] is not None
-        assert action_output["chain"] is not None
         assert action_output["csr"] is not None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -181,10 +181,6 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(secret["certificate"], CERTIFICATE)
         self.assertEqual(secret["ca-certificate"], CA)
         self.assertEqual(
-            secret["chain"],
-            json.dumps(chain),
-        )
-        self.assertEqual(
             secret["csr"],
             CSR,
         )
@@ -228,7 +224,6 @@ class TestCharm(unittest.TestCase):
             content={
                 "certificate": "old certificate",
                 "ca-certificate": "old ca certificate",
-                "chain": "old chain",
             },
             label="certificate-0",
         )
@@ -246,10 +241,6 @@ class TestCharm(unittest.TestCase):
         )
         self.assertEqual(secret_content["certificate"], CERTIFICATE)
         self.assertEqual(secret_content["ca-certificate"], CA)
-        self.assertEqual(
-            secret_content["chain"],
-            json.dumps(chain),
-        )
         self.assertEqual(
             secret_content["csr"],
             CSR,
@@ -274,7 +265,6 @@ class TestCharm(unittest.TestCase):
             content={
                 "certificate": CERTIFICATE,
                 "ca-certificate": CA,
-                "chain": json.dumps(chain),
                 "csr": CSR,
             },
             label="certificate-0",
@@ -286,7 +276,6 @@ class TestCharm(unittest.TestCase):
             {
                 "certificate": CERTIFICATE,
                 "ca-certificate": CA,
-                "chain": chain,
                 "csr": CSR,
             }
         )
@@ -300,7 +289,6 @@ class TestCharm(unittest.TestCase):
             content={
                 "certificate": "whatever",
                 "ca-certificate": CA,
-                "chain": "whatever chain",
             },
             label="certificate-0",
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import unittest
 from unittest.mock import Mock, patch
 
@@ -258,7 +257,6 @@ class TestCharm(unittest.TestCase):
         self,
     ):
         self.harness.set_leader(is_leader=True)
-        chain = ["whatever chain"]
         event = Mock()
         self._add_model_secret(
             owner=self.harness.model.unit.name,


### PR DESCRIPTION
# Description

There was a bug where the CA chain was to big to be stored in a Juju secret. As the chain is not used by this charm, we simply remove any behavior storing and retrieving it.

Fixes #38 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
