### PR TITLE
docs: Adds link to Charmhub discourse documentation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,7 @@ description: |
 website: https://charmhub.io/tls-certificates-requirer
 source: https://github.com/canonical/tls-certificates-requirer-operator
 issues: https://github.com/canonical/tls-certificates-requirer-operator/issues
+docs: https://discourse.charmhub.io/t/tls-certificates-requirer/12977
 
 requires:
   certificates:


### PR DESCRIPTION
# Description

Adds link to Charmhub discourse documentation so that this charm's documentation can be managed the same way as the other TLS Certificates charms.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
