### PR TITLE
chore: use ruff for linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,19 +14,34 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
+[tool.pyright]
+include = ["src/**.py"]
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,13 +7,14 @@
 import logging
 import secrets
 
-from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
     TLSCertificatesRequiresV3,
     generate_csr,
     generate_private_key,
 )
-from ops.charm import ActionEvent, CharmBase, EventBase, InstallEvent, RelationBrokenEvent
+from ops.charm import ActionEvent, CharmBase, InstallEvent, RelationBrokenEvent
+from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, SecretNotFoundError
 
@@ -24,7 +25,7 @@ class TLSRequirerOperatorCharm(CharmBase):
     """TLS Requirer Operator Charm."""
 
     def __init__(self, *args):
-        """Handles events for certificate management."""
+        """Handle events for certificate management."""
         super().__init__(*args)
         self.certificates = TLSCertificatesRequiresV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)
@@ -50,7 +51,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         return self._relation_created("certificates")
 
     def _relation_created(self, relation_name: str) -> bool:
-        """Returns whether given relation was created.
+        """Return whether given relation was created.
 
         Args:
             relation_name (str): Relation name
@@ -64,7 +65,7 @@ class TLSRequirerOperatorCharm(CharmBase):
             return False
 
     def _on_install(self, event: InstallEvent) -> None:
-        """Generates password and private key and stores them in a Juju secret.
+        """Generate password and private key and stores them in a Juju secret.
 
         Args:
             event: Juju event.
@@ -82,7 +83,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         self.unit.status = ActiveStatus()
 
     def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Removes Certificate from juju secret.
+        """Remove Certificate from juju secret.
 
         Args:
             event: Juju event.
@@ -92,7 +93,7 @@ class TLSRequirerOperatorCharm(CharmBase):
             certificate_secret.remove_all_revisions()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
-        """Stores the certificate in a Juju secret.
+        """Store the certificate in a Juju secret.
 
         Args:
             event: Juju Event
@@ -119,7 +120,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         self.unit.status = ActiveStatus("Certificate is available")
 
     def _on_certificates_relation_joined(self, event: EventBase) -> None:
-        """Validates config and requests a new certificate.
+        """Validate config and requests a new certificate.
 
         Args:
             event: Juju event.
@@ -131,7 +132,7 @@ class TLSRequirerOperatorCharm(CharmBase):
             self.unit.status = ActiveStatus("Certificate request is sent")
 
     def _get_unit_common_name(self) -> str:
-        """Returns common name for the unit.
+        """Return common name for the unit.
 
         If `common_name` config option is set, it will be used as a common name.
         Otherwise, the common name will be generated based on the application name and unit number.
@@ -151,7 +152,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         )
 
     def _request_certificate(self) -> None:
-        """Requests X.509 certificate.
+        """Request X.509 certificate.
 
         Retrieves private key and password from Juju secret, generates a certificate
         signing request (CSR) and inserts it into the `certificates` relation unit relation data.
@@ -165,7 +166,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         )
 
     def _generate_csr(self, common_name: str) -> None:
-        """Generates CSR based on private key and stores it in Juju secret."""
+        """Generate CSR based on private key and stores it in Juju secret."""
         if not self._private_key_is_stored:
             raise RuntimeError("Private key not stored.")
         private_key_secret = self.model.get_secret(label=self._get_private_key_secret_label())
@@ -198,7 +199,7 @@ class TLSRequirerOperatorCharm(CharmBase):
 
     @property
     def _certificate_is_stored(self) -> bool:
-        """Returns whether certificate is available in Juju secret.
+        """Return whether certificate is available in Juju secret.
 
         Returns:
             bool: Whether certificate is stored
@@ -206,7 +207,7 @@ class TLSRequirerOperatorCharm(CharmBase):
         return self._secret_exists(label=self._get_certificate_secret_label())
 
     def _secret_exists(self, label: str) -> bool:
-        """Returns whether a given secret exists.
+        """Return whether a given secret exists.
 
         Args:
             label: Juju secret label
@@ -253,7 +254,7 @@ class TLSRequirerOperatorCharm(CharmBase):
 
 
 def generate_password() -> str:
-    """Generates a random string containing 64 bytes.
+    """Generate a random string containing 64 bytes.
 
     Returns:
         str: Password

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,14 +1,8 @@
 black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju>=3.1.6
-mypy
-pep8-naming
-pyproject-flake8
+pyright
 pytest
 pytest-operator
-types-PyYAML
-types-setuptools
-types-toml
+ruff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,54 +10,52 @@ bcrypt==4.1.2
     # via paramiko
 black==24.2.0
     # via -r test-requirements.in
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 certifi==2023.11.17
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 click==8.1.7
     # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.3
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==6.1.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.2.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
-google-auth==2.27.0
+google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
     # via juju
 idna==3.6
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.20.0
+ipython==8.22.1
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
@@ -69,20 +67,19 @@ juju==3.3.1.1
 kubernetes==29.0.0
     # via juju
 macaroonbakery==1.3.4
-    # via juju
-markupsafe==2.1.4
+    # via
+    #   -c requirements.txt
+    #   juju
+markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
-mypy==1.8.0
-    # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
-    #   mypy
     #   typing-inspect
+nodeenv==1.8.0
+    # via pyright
 oauthlib==3.2.2
     # via
     #   kubernetes
@@ -92,24 +89,24 @@ packaging==23.2
     #   black
     #   juju
     #   pytest
-paramiko==2.12.0
+paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
 pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via black
 pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.2
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -121,29 +118,29 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.1.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -c requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==6.1.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
+    #   -c requirements.txt
     #   juju
     #   macaroonbakery
+pyright==1.1.352
+    # via -r test-requirements.in
 pytest==8.0.2
     # via
     #   -r test-requirements.in
@@ -156,14 +153,18 @@ pytest-operator==0.34.0
 python-dateutil==2.8.2
     # via kubernetes
 pytz==2023.3.post1
-    # via pyrfc3339
+    # via
+    #   -c requirements.txt
+    #   pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
@@ -172,16 +173,16 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.0
+    # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -190,25 +191,23 @@ traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
-types-pyyaml==6.0.12.12
-    # via -r test-requirements.in
-types-setuptools==69.1.0.20240229
-    # via -r test-requirements.in
-types-toml==0.10.8.7
-    # via -r test-requirements.in
-typing-extensions==4.9.0
-    # via
-    #   mypy
-    #   typing-inspect
+typing-extensions==4.10.0
+    # via typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.1.0
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -36,7 +36,7 @@ async def build_and_deploy(ops_test: OpsTest):
 
 
 async def wait_for_certificate_available(ops_test: OpsTest, unit_name: str) -> dict:
-    """Runs the `get-certificate` action until it returns a certificate.
+    """Run the `get-certificate` action until it returns a certificate.
 
     If the action does not return a certificate within 60 seconds, a TimeoutError is raised.
     """

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,10 +5,9 @@ import unittest
 from unittest.mock import Mock, patch
 
 import pytest
+from charm import TLSRequirerOperatorCharm
 from ops import testing
 from ops.model import ActiveStatus, SecretNotFoundError
-
-from charm import TLSRequirerOperatorCharm
 
 PRIVATE_KEY = "whatever private key"
 PRIVATE_KEY_PASSWORD = "whatever password"
@@ -27,7 +26,7 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
     def _add_model_secret(self, owner: str, content: dict, label: str) -> None:
-        """Adds a secret to the model.
+        """Add a secret to the model.
 
         Args:
             owner: Secret owner.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
-skipsdist=True
+no_package = True
 skip_missing_interpreters = True
-envlist = lint, unit, static
+env_list = format, lint, static, unit
+min_version = 4.0.0
 
 [vars]
 src_path = {toxinidir}/src/
@@ -13,37 +14,35 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
-setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=pdb.set_trace
-  PY_COLORS=1
+set_env =
+    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-passenv =
-  PYTHONPATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
-[testenv:fmt]
+[testenv:format]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
     black {[vars]all_path}
+    ruff --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static]
-description = Run static analysis checks
-setenv =
-    PYTHONPATH = ""
+description = Run static type checks
 commands =
-    mypy {[vars]all_path} {posargs}
+    pyright {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description

In order to standardise with the new default linter for charms and between TLS projects, we are moving the lint checks from  `pflake8` and `isort` to `ruff`. We also take the opportunity to "rebase" the tox.ini and pyproject.toml files onto what's default coming out of `charmcraft init`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
