### PR TITLE
fix: get latest version of secret

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -111,7 +111,7 @@ class TLSRequirerCharm(CharmBase):
             event: Juju Event
         """
         csr_secret = self.model.get_secret(label=self._get_csr_secret_label())
-        csr_secret_content = csr_secret.get_content()
+        csr_secret_content = csr_secret.get_content(refresh=True)
         if csr_secret_content["csr"].strip() != event.certificate_signing_request:
             logger.info("New certificate CSR doesn't match with the one stored.")
             return
@@ -158,7 +158,7 @@ class TLSRequirerCharm(CharmBase):
         if not self._csr_is_stored:
             return
         secret = self.model.get_secret(label=self._get_csr_secret_label())
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         self.certificates.request_certificate_revocation(
             certificate_signing_request=secret_content["csr"].encode()
         )
@@ -172,7 +172,7 @@ class TLSRequirerCharm(CharmBase):
         if not self._csr_is_stored:
             raise RuntimeError("CSR is not stored")
         csr_secret = self.model.get_secret(label=self._get_csr_secret_label())
-        csr_secret_content = csr_secret.get_content()
+        csr_secret_content = csr_secret.get_content(refresh=True)
         self.certificates.request_certificate_creation(
             certificate_signing_request=csr_secret_content["csr"].encode()
         )
@@ -183,7 +183,7 @@ class TLSRequirerCharm(CharmBase):
         if not self._private_key_is_stored:
             raise RuntimeError("Private key not stored.")
         private_key_secret = self.model.get_secret(label=self._get_private_key_secret_label())
-        private_key_secret_content = private_key_secret.get_content()
+        private_key_secret_content = private_key_secret.get_content(refresh=True)
         csr = generate_csr(
             private_key=private_key_secret_content["private-key"].encode(),
             private_key_password=private_key_secret_content["private-key-password"].encode(),
@@ -243,7 +243,7 @@ class TLSRequirerCharm(CharmBase):
         """
         if self._certificate_is_stored:
             secret = self.model.get_secret(label=self._get_certificate_secret_label())
-            content = secret.get_content()
+            content = secret.get_content(refresh=True)
             event.set_results(
                 {
                     "certificate": content["certificate"],


### PR DESCRIPTION
# Description

It was the case that when the tls provider would send a new cert, we would store it in secrets but we would never actually use it. When running `get-certificate` we would still get the old one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
