### PR TITLE
chore: use self signed cert operator from stable risk

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -78,7 +78,7 @@ async def test_given_self_signed_certificates_is_related_when_deployed_then_stat
     await ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_CHARM_NAME,
-        channel="edge",
+        channel="stable",
     )
     await ops_test.model.wait_for_idle(
         apps=[SELF_SIGNED_CERTIFICATES_CHARM_NAME],


### PR DESCRIPTION
# Description

Use tls provider from stable risk, reducing the risk of tests failing because of issues in other charms used in tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
