### PR TITLE
fix: Revert "Adds dependency groupping and uses weekly schedule in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
-    groups:
-      github_actions:
-        patterns:
-          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
-    groups:
-      pip_dependencies:
-        patterns:
-          - "*"


### PR DESCRIPTION
# Description

This reverts commit 253a9c0678875cbd8d8f958d0972604375d2fa61.

The commit was pushed to main by mistake and the protection rules did not catch it. Protection rules are fixed now, commit is reverted here, and a PR with the same change will be created for review.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
