### PR TITLE
feat: add common csr configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+venv/
+build/
+*.charm
+.tox
+
+.coverage
+__pycache__/
+*.py[cod]
+
+.idea/
+.vscode

--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,28 @@ options:
     type: string
     description: |
       Common name to be used in the certificate. If not set, the common name will be <app name>-<unit number>.<model name>
+
+  organization:
+    type: string
+    description: |
+      Organization name to be used in the certificate. If not set, no organization name will be used.
+  
+  email_address:
+    type: string
+    description: |
+      Email address to be used in the certificate. If not set, no email address will be used.
+
+  country_name:
+    type: string
+    description: |
+      Country name to be used in the certificate. If not set, no country name will be used.
+  
+  state_or_province_name:
+    type: string
+    description: |
+      State or province name to be used in the certificate. If not set, no state or province name will be used.
+  
+  locality_name:
+    type: string
+    description: |
+      Locality name to be used in the certificate. If not set, no locality name will be used.

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ options:
     description: |
       Common name to be used in the certificate. If not set, the common name will be <app name>-<unit number>.<model name>
 
-  organization:
+  organization_name:
     type: string
     description: |
       Organization name to be used in the certificate. If not set, no organization name will be used.

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,7 +91,7 @@ class TLSRequirerCharm(CharmBase):
         if not self._csr_is_stored:
             self._generate_csr(
                 common_name=self._get_unit_common_name(),
-                organization=self._get_config_organization(),
+                organization=self._get_config_organization_name(),
                 email_address=self._get_config_email_address(),
                 country_name=self._get_config_country_name(),
                 state_or_province_name=self._get_config_state_or_province_name(),
@@ -162,9 +162,9 @@ class TLSRequirerCharm(CharmBase):
             return config_common_name
         return f"{self.app.name}-{self._get_unit_number()}.{self.model.name}"
 
-    def _get_config_organization(self) -> Optional[str]:
+    def _get_config_organization_name(self) -> Optional[str]:
         """Return organization name from the configuration."""
-        return self.model.config.get("organization", None)
+        return self.model.config.get("organization_name", None)
 
     def _get_config_email_address(self) -> Optional[str]:
         """Return email address from the configuration."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 import logging
 import secrets
 import typing
+from typing import Optional
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
@@ -88,7 +89,14 @@ class TLSRequirerCharm(CharmBase):
         if not self._private_key_is_stored:
             self._generate_private_key()
         if not self._csr_is_stored:
-            self._generate_csr(common_name=self._get_unit_common_name())
+            self._generate_csr(
+                common_name=self._get_unit_common_name(),
+                organization=self._get_config_organization(),
+                email_address=self._get_config_email_address(),
+                country_name=self._get_config_country_name(),
+                state_or_province_name=self._get_config_state_or_province_name(),
+                locality_name=self._get_config_locality_name(),
+            )
         if not self._certificates_relation_created:
             return
         if not self._certificate_is_stored:
@@ -154,6 +162,26 @@ class TLSRequirerCharm(CharmBase):
             return config_common_name
         return f"{self.app.name}-{self._get_unit_number()}.{self.model.name}"
 
+    def _get_config_organization(self) -> Optional[str]:
+        """Return organization name from the configuration."""
+        return self.model.config.get("organization", None)
+
+    def _get_config_email_address(self) -> Optional[str]:
+        """Return email address from the configuration."""
+        return self.model.config.get("email_address", None)
+
+    def _get_config_country_name(self) -> Optional[str]:
+        """Return country name from the configuration."""
+        return self.model.config.get("country_name", None)
+
+    def _get_config_state_or_province_name(self) -> Optional[str]:
+        """Return state or province name from the configuration."""
+        return self.model.config.get("state_or_province_name", None)
+
+    def _get_config_locality_name(self) -> Optional[str]:
+        """Return locality name from the configuration."""
+        return self.model.config.get("locality_name", None)
+
     def _revoke_existing_certificates(self) -> None:
         if not self._csr_is_stored:
             return
@@ -178,7 +206,15 @@ class TLSRequirerCharm(CharmBase):
         )
         logger.info("Certificate request sent")
 
-    def _generate_csr(self, common_name: str) -> None:
+    def _generate_csr(
+            self,
+            common_name: str,
+            organization: Optional[str],
+            email_address: Optional[str],
+            country_name: Optional[str],
+            state_or_province_name: Optional[str] = None,
+            locality_name: Optional[str] = None,
+        ) -> None:
         """Generate CSR based on private key and stores it in Juju secret."""
         if not self._private_key_is_stored:
             raise RuntimeError("Private key not stored.")
@@ -188,6 +224,11 @@ class TLSRequirerCharm(CharmBase):
             private_key=private_key_secret_content["private-key"].encode(),
             private_key_password=private_key_secret_content["private-key-password"].encode(),
             subject=common_name,
+            organization=organization,
+            email_address=email_address,
+            country_name=country_name,
+            state_or_province_name=state_or_province_name,
+            locality_name=locality_name,
         )
         csr_secret_content = {"csr": csr.decode()}
         self.unit.add_secret(content=csr_secret_content, label=self._get_csr_secret_label())

--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+from typing import Optional
+
+from cryptography import x509
+
+
+class Certificate:
+    def __init__(self, certificate_str: str):
+        """Initialize the Certificate class.
+
+        Args:
+          certificate_str (str): The certificate in PEM format.
+        """
+        self.certificate_str = certificate_str
+        self.certificate = x509.load_pem_x509_certificate(self.certificate_str.encode("utf-8"))
+
+    @property
+    def subject(self) -> Optional[str]:
+        return self.certificate.subject.rfc4514_string()
+
+    @property
+    def organization_name(self) -> Optional[str]:
+        try:
+            org = self.certificate.subject.get_attributes_for_oid(
+                x509.NameOID.ORGANIZATION_NAME
+            )[0].value
+        except IndexError:
+            return None
+        return str(org)
+
+    @property
+    def email_address(self) -> Optional[str]:
+        try:
+            email = self.certificate.subject.get_attributes_for_oid(
+                x509.NameOID.EMAIL_ADDRESS
+            )[0].value
+        except IndexError:
+            return None
+        return str(email)
+
+    @property
+    def country_name(self) -> Optional[str]:
+        try:
+            country = self.certificate.subject.get_attributes_for_oid(
+                x509.NameOID.COUNTRY_NAME
+            )[0].value
+        except IndexError:
+            return None
+        return str(country)
+
+    @property
+    def state_or_province_name(self) -> Optional[str]:
+        try:
+            state = self.certificate.subject.get_attributes_for_oid(
+                x509.NameOID.STATE_OR_PROVINCE_NAME
+            )[0].value
+        except IndexError:
+            return None
+        return str(state)
+
+    @property
+    def locality_name(self) -> Optional[str]:
+        try:
+            locality = self.certificate.subject.get_attributes_for_oid(
+                x509.NameOID.LOCALITY_NAME
+            )[0].value
+        except IndexError:
+            return None
+        return str(locality)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from certificates import Certificate
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,12 @@ async def deploy(ops_test: OpsTest, request):
     charm = Path(request.config.getoption("--charm_path")).resolve()
     await ops_test.model.deploy(
         charm,
+        config={
+            "organization_name": "Canonical",
+            "country_name": "GB",
+            "state_or_province_name": "London",
+            "locality_name": "London",
+        },
         application_name=APP_NAME,
         series="jammy",
         trust=True,
@@ -107,3 +114,11 @@ async def test_given_self_signed_certificates_is_related_when_get_certificate_ac
         assert action_output["certificate"] is not None
         assert action_output["ca-certificate"] is not None
         assert action_output["csr"] is not None
+
+        certificate = Certificate(action_output["certificate"])
+
+        assert certificate.organization_name == "Canonical"
+        assert certificate.country_name == "GB"
+        assert certificate.state_or_province_name == "London"
+        assert certificate.locality_name == "London"
+        assert certificate.email_address is None

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -22,7 +22,6 @@ NUM_UNITS = 3
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy(ops_test: OpsTest, request):
     """Deploy charm under test."""
     assert ops_test.model
@@ -37,7 +36,6 @@ async def deploy(ops_test: OpsTest, request):
         },
         application_name=APP_NAME,
         series="jammy",
-        trust=True,
         num_units=NUM_UNITS,
     )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -94,6 +94,11 @@ class TestCharm(unittest.TestCase):
             private_key=PRIVATE_KEY.encode(),
             private_key_password=PRIVATE_KEY_PASSWORD.encode(),
             subject=f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}",
+            organization=None,
+            email_address=None,
+            country_name=None,
+            state_or_province_name=None,
+            locality_name=None,
         )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()
@@ -124,6 +129,11 @@ class TestCharm(unittest.TestCase):
             private_key=PRIVATE_KEY.encode(),
             private_key_password=PRIVATE_KEY_PASSWORD.encode(),
             subject=SUBJECT,
+            organization=None,
+            email_address=None,
+            country_name=None,
+            state_or_province_name=None,
+            locality_name=None,
         )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=CSR.encode()


### PR DESCRIPTION
# Description

Add the following optional configuration options which will be used in every generated CSR:
- `organization_name`: Organization name to be used in the certificate. If not set, no organization name will be used.
- `email_address`: Email address to be used in the certificate. If not set, no email address will be used.
- `country_name`: Country name to be used in the certificate. If not set, no country name will be used.
- `state_or_province_name`: State or province name to be used in the certificate. If not set, no state or province name will be used.
- `locality_name`: Locality name to be used in the certificate. If not set, no locality name will be used.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
