### PR TITLE
feat: add sans_dns configuration option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,29 +2,41 @@ options:
   common_name:
     type: string
     description: |
-      Common name to be used in the certificate. If not set, the common name will be <app name>-<unit number>.<model name>
+      Common name to be used in the certificate.
+      If not set, the following value will be used: `<app name>-<unit number>.<model name>`
+
+  sans_dns:
+    type: string
+    description: |
+      Comma separated list of DNS Subject Alternative Names (SAN's) to be used in the certificate.
+      If not set, the following value will be used: `<app name>-<unit number>.<model name>`
 
   organization_name:
     type: string
     description: |
-      Organization name to be used in the certificate. If not set, no organization name will be used.
+      Organization name to be used in the certificate.
+      If not set, no organization name will be used.
   
   email_address:
     type: string
     description: |
-      Email address to be used in the certificate. If not set, no email address will be used.
+      Email address to be used in the certificate.
+      If not set, no email address will be used.
 
   country_name:
     type: string
     description: |
-      Country name to be used in the certificate. If not set, no country name will be used.
+      Country name to be used in the certificate.
+      If not set, no country name will be used.
   
   state_or_province_name:
     type: string
     description: |
-      State or province name to be used in the certificate. If not set, no state or province name will be used.
+      State or province name to be used in the certificate.
+      If not set, no state or province name will be used.
   
   locality_name:
     type: string
     description: |
-      Locality name to be used in the certificate. If not set, no locality name will be used.
+      Locality name to be used in the certificate.
+      If not set, no locality name will be used.

--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -3,7 +3,7 @@
 # See LICENSE file for licensing details.
 
 
-from typing import Optional
+from typing import List, Optional
 
 from cryptography import x509
 
@@ -21,6 +21,16 @@ class Certificate:
     @property
     def subject(self) -> Optional[str]:
         return self.certificate.subject.rfc4514_string()
+
+    @property
+    def sans_dns(self) -> List[str]:
+        try:
+            sans = self.certificate.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value.get_values_for_type(x509.DNSName)
+        except x509.ExtensionNotFound:
+            return []
+        return [str(san) for san in sans]
 
     @property
     def organization_name(self) -> Optional[str]:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -29,6 +29,7 @@ async def deploy(ops_test: OpsTest, request):
     await ops_test.model.deploy(
         charm,
         config={
+            "sans_dns": "example.com,example.org",
             "organization_name": "Canonical",
             "country_name": "GB",
             "state_or_province_name": "London",
@@ -120,3 +121,4 @@ async def test_given_self_signed_certificates_is_related_when_get_certificate_ac
         assert certificate.state_or_province_name == "London"
         assert certificate.locality_name == "London"
         assert certificate.email_address is None
+        assert certificate.sans_dns == ["example.com", "example.org"]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -121,4 +121,6 @@ async def test_given_self_signed_certificates_is_related_when_get_certificate_ac
         assert certificate.state_or_province_name == "London"
         assert certificate.locality_name == "London"
         assert certificate.email_address is None
-        assert certificate.sans_dns == ["example.com", "example.org"]
+        assert len(certificate.sans_dns) == 2
+        assert "example.com" in certificate.sans_dns
+        assert "example.org" in certificate.sans_dns

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -94,6 +94,7 @@ class TestCharm(unittest.TestCase):
             private_key=PRIVATE_KEY.encode(),
             private_key_password=PRIVATE_KEY_PASSWORD.encode(),
             subject=f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}",
+            sans_dns=[f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}"],
             organization=None,
             email_address=None,
             country_name=None,
@@ -125,10 +126,49 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_id, remote_unit_name="certificates-provider/0"
         )
 
+        unit_number = self.harness.model.unit.name.split("/")[1]
         patch_generate_csr.assert_called_with(
             private_key=PRIVATE_KEY.encode(),
             private_key_password=PRIVATE_KEY_PASSWORD.encode(),
             subject=SUBJECT,
+            sans_dns=[f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}"],
+            organization=None,
+            email_address=None,
+            country_name=None,
+            state_or_province_name=None,
+            locality_name=None,
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=CSR.encode()
+        )
+
+    @patch("charm.generate_csr")
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"  # noqa: E501, W505
+    )
+    def test_given_sans_dns_config_is_set_when_certificates_relation_joined_then_certificate_is_requested_with_sans_dns(  # noqa: E501
+        self,
+        patch_request_certificate_creation,
+        patch_generate_csr,
+    ):
+        self.harness.update_config({"sans_dns": "banana.com,apple.com"})
+        patch_generate_csr.return_value = CSR.encode()
+        self.harness.set_leader(is_leader=True)
+        self._store_private_key()
+        relation_id = self.harness.add_relation(
+            relation_name="certificates", remote_app="certificates-provider"
+        )
+
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name="certificates-provider/0"
+        )
+
+        unit_number = self.harness.model.unit.name.split("/")[1]
+        patch_generate_csr.assert_called_with(
+            private_key=PRIVATE_KEY.encode(),
+            private_key_password=PRIVATE_KEY_PASSWORD.encode(),
+            subject=f"{self.harness.charm.app.name}-{unit_number}.{self.harness.model.name}",
+            sans_dns=["banana.com", "apple.com"],
             organization=None,
             email_address=None,
             country_name=None,


### PR DESCRIPTION
# Description

Add `sans_dns` configuration option which takes a comma separated list of DNS Subject Alternative Names (SAN's) and inserts those in the certificate signing request (CSR).  If not set, the following value will be used: `<app name>-<unit number>.<model name>`.

Fixes #118 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
