### PR TITLE
feat: add per-app certificate management

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -50,17 +50,31 @@ requires:
 
 config:
   options:
+
+    mode:
+      type: string
+      default: "unit"
+      description: |
+        Mode in which the charm will request the certificate.
+        Allowed values:
+          - `unit`: Certificates are managed at the unit level. Each unit will have its own certificate.
+          - `app`: Certificates are managed at the application level. The application can have 1 or more certificates.
+
     common_name:
       type: string
       description: |
         Common name to be used in the certificate.
-        If not set, the following value will be used: `<app name>-<unit number>-<certificate number>.<model name>`
+        If not set, the following value will be used (depending on the mode):
+          - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
+          - `app`: `<app name>-<certificate number>.<model name>`
 
     sans_dns:
       type: string
       description: |
         Comma separated list of DNS Subject Alternative Names (SAN's) to be used in the certificate.
-        If not set, the following value will be used: `<app name>-<unit number>-<certificate number>.<model name>`
+        If not set, the following value will be used (depending on the mode):
+          - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
+          - `app`: `<app name>-<certificate number>.<model name>`
 
     organization_name:
       type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,15 +76,15 @@ class TLSRequirerCharm(CharmBase):
             return
         mode = self._get_config_mode()
         if mode == "unit":
-            status = self._collect_unit_status()
+            status = self._collect_status_unit_mode()
             event.add_status(status)
             return
         elif mode == "app":
-            status = self._collect_app_status()
+            status = self._collect_status_app_mode()
             event.add_status(status)
             return
 
-    def _collect_unit_status(self) -> StatusBase:
+    def _collect_status_unit_mode(self) -> StatusBase:
         """Collect status for the unit mode."""
         if not self._unit_private_key_is_stored:
             return WaitingStatus("Waiting for unit private key to be generated")
@@ -96,7 +96,7 @@ class TLSRequirerCharm(CharmBase):
             return ActiveStatus("Unit certificate request is sent")
         return ActiveStatus("Unit certificate is available")
 
-    def _collect_app_status(self) -> StatusBase:
+    def _collect_status_app_mode(self) -> StatusBase:
         """Collect status for the app mode."""
         if not self._app_private_key_is_stored:
             return WaitingStatus("Waiting for app private key to be generated")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,43 +2,21 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
+import asyncio
 import logging
 import time
 from pathlib import Path
 
 import pytest
-import yaml
 from certificates import Certificate
+from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-APP_NAME = METADATA["name"]
 SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 
 NUM_UNITS = 3
-
-
-@pytest.fixture(scope="module")
-async def deploy(ops_test: OpsTest, request):
-    """Deploy charm under test."""
-    assert ops_test.model
-    charm = Path(request.config.getoption("--charm_path")).resolve()
-    await ops_test.model.deploy(
-        charm,
-        config={
-            "sans_dns": "example.com,example.org",
-            "organization_name": "Canonical",
-            "country_name": "GB",
-            "state_or_province_name": "London",
-            "locality_name": "London",
-        },
-        application_name=APP_NAME,
-        series="jammy",
-        num_units=NUM_UNITS,
-    )
 
 
 async def wait_for_certificate_available(ops_test: OpsTest, unit_name: str) -> dict:
@@ -63,51 +41,196 @@ async def wait_for_certificate_available(ops_test: OpsTest, unit_name: str) -> d
     raise TimeoutError("Timed out waiting for certificate")
 
 
-@pytest.mark.abort_on_fail
-async def test_given_charm_is_built_when_deployed_then_status_is_active(
-    ops_test: OpsTest,
-    deploy,
-):
-    assert ops_test.model
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        timeout=1000,
-    )
+async def get_leader_unit(model, application_name: str) -> Unit:
+    """Return the leader unit for the given application."""
+    for unit in model.units.values():
+        if unit.application == application_name and await unit.is_leader_from_status():
+            return unit
+    raise RuntimeError(f"Leader unit for `{application_name}` not found.")
 
 
-async def test_given_self_signed_certificates_is_related_when_deployed_then_status_is_active(  # noqa: E501
-    ops_test: OpsTest,
-    deploy,
-):
-    assert ops_test.model
-    await ops_test.model.deploy(
-        SELF_SIGNED_CERTIFICATES_CHARM_NAME,
-        application_name=SELF_SIGNED_CERTIFICATES_CHARM_NAME,
-        channel="stable",
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[SELF_SIGNED_CERTIFICATES_CHARM_NAME],
-        status="active",
-        timeout=1000,
-    )
-    await ops_test.model.integrate(
-        relation1=f"{SELF_SIGNED_CERTIFICATES_CHARM_NAME}:certificates", relation2=f"{APP_NAME}"
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        timeout=1000,
-    )
+class TestTLSRequirerUnitMode:
+
+    APP_NAME = "tls-requirer-unit"
+    SELF_SIGNED_CERTIFICATES_APP_NAME = "self-signed-certificates-unit"
+
+    @pytest.fixture(scope="module")
+    async def deploy(self, ops_test: OpsTest, request):
+        """Deploy charm under test."""
+        assert ops_test.model
+        charm = Path(request.config.getoption("--charm_path")).resolve()
+        await ops_test.model.deploy(
+            charm,
+            config={
+                "mode": "unit",
+                "sans_dns": "example.com,example.org",
+                "organization_name": "Canonical",
+                "country_name": "GB",
+                "state_or_province_name": "London",
+                "locality_name": "London",
+            },
+            application_name=self.APP_NAME,
+            series="jammy",
+            num_units=NUM_UNITS,
+        )
+        await ops_test.model.deploy(
+            SELF_SIGNED_CERTIFICATES_CHARM_NAME,
+            application_name=self.SELF_SIGNED_CERTIFICATES_APP_NAME,
+            channel="stable",
+        )
+        deployed_apps = [self.APP_NAME, self.SELF_SIGNED_CERTIFICATES_APP_NAME]
+        yield
+        remove_coroutines = [
+            ops_test.model.remove_application(
+                app_name=app_name,
+                destroy_storage=True,
+            ) for app_name in deployed_apps
+        ]
+        await asyncio.gather(*remove_coroutines)
+
+    @pytest.mark.abort_on_fail
+    async def test_given_charm_is_built_when_deployed_then_status_is_active(
+        self,
+        ops_test: OpsTest,
+        deploy,
+    ):
+        assert ops_test.model
+        await ops_test.model.wait_for_idle(
+            apps=[self.APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+
+    async def test_given_self_signed_certificates_deployed_when_integrate_then_status_is_active(  # noqa: E501
+        self,
+        ops_test: OpsTest,
+        deploy,
+    ):
+        assert ops_test.model
+        await ops_test.model.wait_for_idle(
+            apps=[self.SELF_SIGNED_CERTIFICATES_APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+        await ops_test.model.integrate(
+            relation1=f"{self.SELF_SIGNED_CERTIFICATES_APP_NAME}:certificates",
+            relation2=f"{self.APP_NAME}"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[self.APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+
+    async def test_given_self_signed_certificates_is_related_when_get_certificate_action_then_certificate_is_returned(  # noqa: E501
+        self,
+        ops_test,
+        deploy,
+    ):
+        for unit in range(NUM_UNITS):
+            action_output = await wait_for_certificate_available(
+                ops_test=ops_test, unit_name=f"{self.APP_NAME}/{unit}"
+            )
+
+            assert action_output["certificate"] is not None
+            assert action_output["ca-certificate"] is not None
+            assert action_output["csr"] is not None
+
+            certificate = Certificate(action_output["certificate"])
+
+            assert certificate.organization_name == "Canonical"
+            assert certificate.country_name == "GB"
+            assert certificate.state_or_province_name == "London"
+            assert certificate.locality_name == "London"
+            assert certificate.email_address is None
+            assert len(certificate.sans_dns) == 2
+            assert "example.com" in certificate.sans_dns
+            assert "example.org" in certificate.sans_dns
 
 
-async def test_given_self_signed_certificates_is_related_when_get_certificate_action_then_certificate_is_returned(  # noqa: E501
-    ops_test,
-    deploy,
-):
-    for unit in range(NUM_UNITS):
+class TestTLSRequirerAppMode:
+
+    APP_NAME = "tls-requirer-app"
+    SELF_SIGNED_CERTIFICATES_APP_NAME = "self-signed-certificates-app"
+
+    @pytest.fixture(scope="module")
+    async def deploy(self, ops_test: OpsTest, request):
+        """Deploy charm under test."""
+        assert ops_test.model
+        charm = Path(request.config.getoption("--charm_path")).resolve()
+        await ops_test.model.deploy(
+            charm,
+            config={
+                "mode": "app",
+                "sans_dns": "example.com,example.org",
+                "organization_name": "Canonical",
+                "country_name": "GB",
+                "state_or_province_name": "London",
+                "locality_name": "London",
+            },
+            application_name=self.APP_NAME,
+            series="jammy",
+            num_units=NUM_UNITS,
+        )
+        await ops_test.model.deploy(
+            SELF_SIGNED_CERTIFICATES_CHARM_NAME,
+            application_name=self.SELF_SIGNED_CERTIFICATES_APP_NAME,
+            channel="stable",
+        )
+        deployed_apps = [self.APP_NAME, self.SELF_SIGNED_CERTIFICATES_APP_NAME]
+        yield
+        remove_coroutines = [
+            ops_test.model.remove_application(
+                app_name=app_name,
+                destroy_storage=True,
+                block_until_done=True,
+            ) for app_name in deployed_apps
+        ]
+        await asyncio.gather(*remove_coroutines)
+
+
+    @pytest.mark.abort_on_fail
+    async def test_given_charm_is_built_when_deployed_then_status_is_active(
+        self,
+        ops_test: OpsTest,
+        deploy,
+    ):
+        assert ops_test.model
+        await ops_test.model.wait_for_idle(
+            apps=[self.APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+
+    async def test_given_self_signed_certificates_is_deployed_when_integrate_then_status_is_active(  # noqa: E501
+        self,
+        ops_test: OpsTest,
+        deploy,
+    ):
+        assert ops_test.model
+        await ops_test.model.wait_for_idle(
+            apps=[self.SELF_SIGNED_CERTIFICATES_APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+        await ops_test.model.integrate(
+            relation1=f"{self.SELF_SIGNED_CERTIFICATES_APP_NAME}:certificates",
+            relation2=f"{self.APP_NAME}"
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[self.APP_NAME],
+            status="active",
+            timeout=1000,
+        )
+
+    async def test_given_self_signed_certificates_is_related_when_get_certificate_action_then_certificate_is_returned(  # noqa: E501
+        self,
+        ops_test,
+        deploy,
+    ):
+        leader_unit = await get_leader_unit(ops_test.model, self.APP_NAME)
         action_output = await wait_for_certificate_available(
-            ops_test=ops_test, unit_name=f"{APP_NAME}/{unit}"
+            ops_test=ops_test, unit_name=leader_unit.name
         )
 
         assert action_output["certificate"] is not None


### PR DESCRIPTION
# Description

Add support for a new `app` mode which makes it possible for TLS certificates Requirer to manage certificates at the application level. We now support two modes:
- `unit`: Certificate management at the unit level. Each unit manges its own private key and certificate. This is to represent the generic TLS requirer use case (ex. web servers).
- `app`: certificate management at the app level. This is to represent the ingress use case (or TLS constraints) where tls certs are managed at the application level. Only the leader will unit handles certificate management and the secrets are owned by the application. Though at the moment only 1 certificate per app is supported, with this mechanics in place, it will be easy to add support for more. This is a pre-requisite step to addressing the feature request of supporting multiple certificates.

## Reviewing this PR

I recommend starting by reading the config option changes in `charmcraft.yaml` to see the user facing changes, then moving on to implementation details.

## Backward compatibility

This change should not break anything as the default mode is `unit`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
