### PR TITLE
feat: build on arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   build-charm-under-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
     
@@ -23,6 +30,6 @@ jobs:
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: "*.charm"
           retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,15 +5,22 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Fetch Charm Under Test
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: built/
       
       - name: Get Charm Under Test Path
@@ -31,7 +38,7 @@ jobs:
       - name: Run integration tests
         run: |
           tox -e integration -- \
-            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+            --charm_path=${{ steps.charm-path.outputs.charm_path }}
   
       - name: Archive charmcraft logs
         if: failure()

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,11 +29,25 @@ assumes:
 
 bases:
   - build-on:
-    - name: "ubuntu"
+    - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
     run-on:
-    - name: "ubuntu"
+    - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
 
 parts:
   charm:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import platform
 import time
 from pathlib import Path
 from typing import Optional
@@ -19,6 +20,7 @@ SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 
 NUM_UNITS = 3
 
+ARCH = "arm64" if platform.machine() == "aarch64" else "amd64"
 
 
 async def wait_for_certificate_available(
@@ -88,6 +90,8 @@ class TestTLSRequirerUnitMode:
         """Deploy charm under test."""
         assert ops_test.model
         charm = Path(request.config.getoption("--charm_path")).resolve()
+        logger.info("Deploying charms for architecture: %s", ARCH)
+        await ops_test.model.set_constraints({"arch": ARCH})
         await ops_test.model.deploy(
             charm,
             config={
@@ -101,11 +105,13 @@ class TestTLSRequirerUnitMode:
             application_name=self.APP_NAME,
             series="jammy",
             num_units=NUM_UNITS,
+            constraints={"arch": ARCH},
         )
         await ops_test.model.deploy(
             SELF_SIGNED_CERTIFICATES_CHARM_NAME,
             application_name=self.SELF_SIGNED_CERTIFICATES_APP_NAME,
             channel="stable",
+            constraints={"arch": ARCH},
         )
         await ops_test.model.set_config(config={"update-status-hook-interval": "10s"})
         deployed_apps = [self.APP_NAME, self.SELF_SIGNED_CERTIFICATES_APP_NAME]
@@ -215,6 +221,8 @@ class TestTLSRequirerAppMode:
         """Deploy charm under test."""
         assert ops_test.model
         charm = Path(request.config.getoption("--charm_path")).resolve()
+        logger.info("Deploying charms for architecture: %s", ARCH)
+        await ops_test.model.set_constraints({"arch": ARCH})
         await ops_test.model.deploy(
             charm,
             config={
@@ -228,11 +236,13 @@ class TestTLSRequirerAppMode:
             application_name=self.APP_NAME,
             series="jammy",
             num_units=NUM_UNITS,
+            constraints={"arch": ARCH},
         )
         await ops_test.model.deploy(
             SELF_SIGNED_CERTIFICATES_CHARM_NAME,
             application_name=self.SELF_SIGNED_CERTIFICATES_APP_NAME,
             channel="stable",
+            constraints={"arch": ARCH},
         )
         deployed_apps = [self.APP_NAME, self.SELF_SIGNED_CERTIFICATES_APP_NAME]
         yield


### PR DESCRIPTION
# Description

Here we build TLS Certificates Requirer on arm64 in addition to amd64. TLS Certificates Requirer is used by many other charms (like Vault) in their integration tests and must be compiled on arm64 before its dependents.

## Approach
We take the same approach as self-signed certificates, using Canonical's self-hosted runners and Matrix to dispatch jobs on the appropriate runner. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
