### PR TITLE
style: Format using ruff

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,7 @@ def csr_has_attributes(  # noqa: C901
     email_address: Optional[str],
     country_name: Optional[str],
     state_or_province_name: Optional[str],
-    locality_name: Optional[str]
+    locality_name: Optional[str],
 ) -> bool:
     """Check whether CSR has the specified attributes."""
     csr_object = x509.load_pem_x509_csr(csr.encode())
@@ -50,16 +50,18 @@ def csr_has_attributes(  # noqa: C901
         return False
     if len(csr_country_name) == 0 and country_name:
         return False
-    if len(csr_country_name)!= 0 and csr_country_name[0].value != country_name:
+    if len(csr_country_name) != 0 and csr_country_name[0].value != country_name:
         return False
     if len(csr_state_or_province_name) == 0 and state_or_province_name:
         return False
-    if len(csr_state_or_province_name)!= 0 and \
-      csr_state_or_province_name[0].value != state_or_province_name:
+    if (
+        len(csr_state_or_province_name) != 0
+        and csr_state_or_province_name[0].value != state_or_province_name
+    ):
         return False
     if len(csr_locality_name) == 0 and locality_name:
         return False
-    if len(csr_locality_name)!=0 and csr_locality_name[0].value != locality_name:
+    if len(csr_locality_name) != 0 and csr_locality_name[0].value != locality_name:
         return False
     if len(csr_organization_name) == 0 and organization:
         return False
@@ -67,7 +69,7 @@ def csr_has_attributes(  # noqa: C901
         return False
     if len(csr_email_address) == 0 and email_address:
         return False
-    if len(csr_email_address)!= 0 and csr_email_address[0].value != email_address:
+    if len(csr_email_address) != 0 and csr_email_address[0].value != email_address:
         return False
     sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
     if sorted([str(san.value) for san in sans]) != sorted(sans_dns):
@@ -86,17 +88,13 @@ class TLSRequirerCharm(CharmBase):
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
-        self.framework.observe(
-            self.on.certificates_relation_joined, self._configure
-        )
+        self.framework.observe(self.on.certificates_relation_joined, self._configure)
         self.framework.observe(
             self.on.certificates_relation_broken,
             self._on_certificates_relation_broken,
         )
         self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
-        self.framework.observe(
-            self.certificates.on.certificate_available, self._configure
-        )
+        self.framework.observe(self.certificates.on.certificate_available, self._configure)
 
     @property
     def _certificates_relation_created(self) -> bool:
@@ -494,15 +492,15 @@ class TLSRequirerCharm(CharmBase):
         logger.info("App certificate request sent")
 
     def _generate_unit_csr(
-            self,
-            common_name: str,
-            sans_dns: List[str],
-            organization: Optional[str],
-            email_address: Optional[str],
-            country_name: Optional[str],
-            state_or_province_name: Optional[str],
-            locality_name: Optional[str],
-        ) -> None:
+        self,
+        common_name: str,
+        sans_dns: List[str],
+        organization: Optional[str],
+        email_address: Optional[str],
+        country_name: Optional[str],
+        state_or_province_name: Optional[str],
+        locality_name: Optional[str],
+    ) -> None:
         """Generate unit CSR based on private key and stores it in Juju secret."""
         if not self._unit_private_key_is_stored:
             raise RuntimeError("Private key not stored.")
@@ -532,15 +530,15 @@ class TLSRequirerCharm(CharmBase):
         logger.info("Unit CSR secret updated")
 
     def _generate_app_csr(
-            self,
-            common_name: str,
-            sans_dns: List[str],
-            organization: Optional[str],
-            email_address: Optional[str],
-            country_name: Optional[str],
-            state_or_province_name: Optional[str],
-            locality_name: Optional[str],
-        ) -> None:
+        self,
+        common_name: str,
+        sans_dns: List[str],
+        organization: Optional[str],
+        email_address: Optional[str],
+        country_name: Optional[str],
+        state_or_province_name: Optional[str],
+        locality_name: Optional[str],
+    ) -> None:
         """Generate app CSR based on private key and stores it in Juju secret."""
         if not self._app_private_key_is_stored:
             raise RuntimeError("Private key not stored.")

--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -10,6 +10,7 @@ from cryptography import x509
 
 logger = logging.getLogger(__name__)
 
+
 class Certificate:
     def __init__(self, certificate_str: str):
         """Initialize the Certificate class.
@@ -37,9 +38,9 @@ class Certificate:
     @property
     def organization_name(self) -> Optional[str]:
         try:
-            org = self.certificate.subject.get_attributes_for_oid(
-                x509.NameOID.ORGANIZATION_NAME
-            )[0].value
+            org = self.certificate.subject.get_attributes_for_oid(x509.NameOID.ORGANIZATION_NAME)[
+                0
+            ].value
         except IndexError:
             return None
         return str(org)
@@ -47,9 +48,9 @@ class Certificate:
     @property
     def email_address(self) -> Optional[str]:
         try:
-            email = self.certificate.subject.get_attributes_for_oid(
-                x509.NameOID.EMAIL_ADDRESS
-            )[0].value
+            email = self.certificate.subject.get_attributes_for_oid(x509.NameOID.EMAIL_ADDRESS)[
+                0
+            ].value
         except IndexError:
             return None
         return str(email)
@@ -57,9 +58,9 @@ class Certificate:
     @property
     def country_name(self) -> Optional[str]:
         try:
-            country = self.certificate.subject.get_attributes_for_oid(
-                x509.NameOID.COUNTRY_NAME
-            )[0].value
+            country = self.certificate.subject.get_attributes_for_oid(x509.NameOID.COUNTRY_NAME)[
+                0
+            ].value
         except IndexError:
             return None
         return str(country)
@@ -77,9 +78,9 @@ class Certificate:
     @property
     def locality_name(self) -> Optional[str]:
         try:
-            locality = self.certificate.subject.get_attributes_for_oid(
-                x509.NameOID.LOCALITY_NAME
-            )[0].value
+            locality = self.certificate.subject.get_attributes_for_oid(x509.NameOID.LOCALITY_NAME)[
+                0
+            ].value
         except IndexError:
             return None
         return str(locality)
@@ -98,30 +99,30 @@ class Certificate:
             logger.info(
                 "Organization name does not match: %s != %s",
                 self.organization_name,
-                organization_name
+                organization_name,
             )
             return False
         if self.country_name != country_name:
-            logger.info("Country name does not match: %s != %s", self.country_name,  country_name)
+            logger.info("Country name does not match: %s != %s", self.country_name, country_name)
             return False
         if self.state_or_province_name != state_or_province_name:
             logger.info(
                 "State or province name does not match: %s != %s",
                 self.state_or_province_name,
-                state_or_province_name
+                state_or_province_name,
             )
             return False
         if self.locality_name != locality_name:
             logger.info(
-                "Locality name does not match: %s != %s", self.locality_name,  locality_name
+                "Locality name does not match: %s != %s", self.locality_name, locality_name
             )
             return False
         if self.email_address != email_address:
             logger.info(
-                "Email address does not match: %s != %s", self.email_address,  email_address
+                "Email address does not match: %s != %s", self.email_address, email_address
             )
             return False
         if sorted(self.sans_dns) != sorted(sans_dns):
-            logger.info("SANs do not match: %s != %s", self.sans_dns,  sans_dns)
+            logger.info("SANs do not match: %s != %s", self.sans_dns, sans_dns)
             return False
         return True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       parser: The pytest command line parser.
     """
     parser.addoption(
-        "--charm_path",
-        action="store",
-        default=None,
-        help="Path to the charm under test"
+        "--charm_path", action="store", default=None, help="Path to the charm under test"
     )
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,7 +20,6 @@ SELF_SIGNED_CERTIFICATES_CHARM_NAME = "self-signed-certificates"
 NUM_UNITS = 3
 
 
-
 async def wait_for_certificate_available(
     ops_test: OpsTest,
     unit_name: str,
@@ -79,7 +78,6 @@ async def get_leader_unit(model, application_name: str) -> Unit:
 
 
 class TestTLSRequirerUnitMode:
-
     APP_NAME = "tls-requirer-unit"
     SELF_SIGNED_CERTIFICATES_APP_NAME = "self-signed-certificates-unit"
 
@@ -114,7 +112,8 @@ class TestTLSRequirerUnitMode:
             ops_test.model.remove_application(
                 app_name=app_name,
                 destroy_storage=True,
-            ) for app_name in deployed_apps
+            )
+            for app_name in deployed_apps
         ]
         await asyncio.gather(*remove_coroutines)
 
@@ -144,7 +143,7 @@ class TestTLSRequirerUnitMode:
         )
         await ops_test.model.integrate(
             relation1=f"{self.SELF_SIGNED_CERTIFICATES_APP_NAME}:certificates",
-            relation2=f"{self.APP_NAME}"
+            relation2=f"{self.APP_NAME}",
         )
         await ops_test.model.wait_for_idle(
             apps=[self.APP_NAME],
@@ -169,9 +168,8 @@ class TestTLSRequirerUnitMode:
                 sans_dns=["example.com", "example.org"],
             )
 
-
     async def test_given_new_configuration_when_config_changed_then_new_certificate_is_requested(
-            self, ops_test, deploy
+        self, ops_test, deploy
     ):
         assert ops_test.model
         await ops_test.model.wait_for_idle(
@@ -206,7 +204,6 @@ class TestTLSRequirerUnitMode:
 
 
 class TestTLSRequirerAppMode:
-
     APP_NAME = "tls-requirer-app"
     SELF_SIGNED_CERTIFICATES_APP_NAME = "self-signed-certificates-app"
 
@@ -241,10 +238,10 @@ class TestTLSRequirerAppMode:
                 app_name=app_name,
                 destroy_storage=True,
                 block_until_done=True,
-            ) for app_name in deployed_apps
+            )
+            for app_name in deployed_apps
         ]
         await asyncio.gather(*remove_coroutines)
-
 
     @pytest.mark.abort_on_fail
     async def test_given_charm_is_built_when_deployed_then_status_is_active(
@@ -272,7 +269,7 @@ class TestTLSRequirerAppMode:
         )
         await ops_test.model.integrate(
             relation1=f"{self.SELF_SIGNED_CERTIFICATES_APP_NAME}:certificates",
-            relation2=f"{self.APP_NAME}"
+            relation2=f"{self.APP_NAME}",
         )
         await ops_test.model.wait_for_idle(
             apps=[self.APP_NAME],
@@ -298,7 +295,7 @@ class TestTLSRequirerAppMode:
         )
 
     async def test_given_new_configuration_when_config_changed_then_new_certificate_is_requested(
-            self, ops_test, deploy
+        self, ops_test, deploy
     ):
         assert ops_test.model
         await ops_test.model.wait_for_idle(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -29,9 +29,7 @@ CERTIFICATE = "whatever certificate"
 
 class TestCharmUnitMode(unittest.TestCase):
     def setUp(self):
-        self.private_key = generate_private_key(
-            password=PRIVATE_KEY_PASSWORD.encode()
-        )
+        self.private_key = generate_private_key(password=PRIVATE_KEY_PASSWORD.encode())
         self.csr = generate_csr(
             sans_dns=[COMMON_NAME],
             common_name=COMMON_NAME,
@@ -126,9 +124,7 @@ class TestCharmUnitMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
     @patch("charm.generate_csr")
     @patch(
@@ -162,9 +158,7 @@ class TestCharmUnitMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
     @patch("charm.generate_csr")
     @patch(
@@ -198,11 +192,10 @@ class TestCharmUnitMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
     )
     def test_given_certificate_request_is_made_when_evaluate_status_then_status_is_active(
         self,
@@ -249,7 +242,8 @@ class TestCharmUnitMode(unittest.TestCase):
             ActiveStatus("Unit certificate request is sent"),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_csrs_match_when_on_certificate_available_then_certificate_is_stored(
         self,
@@ -288,7 +282,6 @@ class TestCharmUnitMode(unittest.TestCase):
             }
         )
 
-
         self.harness.add_relation_unit(
             relation_id=relation_id, remote_unit_name="certificates-provider/0"
         )
@@ -302,9 +295,11 @@ class TestCharmUnitMode(unittest.TestCase):
             self.csr.decode(),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
     )
     def test_given_certificate_stored_when_on_evaluate_status_then_status_is_active(
         self,
@@ -357,7 +352,6 @@ class TestCharmUnitMode(unittest.TestCase):
                 "country_name": COUNTRY_NAME,
                 "state_or_province_name": STATE_OR_PROVINCE_NAME,
                 "locality_name": LOCALITY_NAME,
-
             }
         )
 
@@ -372,11 +366,11 @@ class TestCharmUnitMode(unittest.TestCase):
             ActiveStatus("Unit certificate is available"),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_certificate_already_stored_when_new_matching_certificate_available_then_certificate_is_overwritten(  # noqa: E501
-        self,
-        patch_get_assigned_certificates
+        self, patch_get_assigned_certificates
     ):
         self._add_model_secret(
             owner=self.harness.model.unit.name,
@@ -402,7 +396,6 @@ class TestCharmUnitMode(unittest.TestCase):
                 "country_name": COUNTRY_NAME,
                 "state_or_province_name": STATE_OR_PROVINCE_NAME,
                 "locality_name": LOCALITY_NAME,
-
             }
         )
         relation_id = self.harness.add_relation(
@@ -438,7 +431,8 @@ class TestCharmUnitMode(unittest.TestCase):
 
         event.fail.assert_called()
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_certificate_is_stored_when_on_get_certificate_action_then_certificate_is_returned(  # noqa: E501
         self,
@@ -551,15 +545,12 @@ class TestCharmUnitMode(unittest.TestCase):
         self.assertEqual(secret_content["csr"], self.csr.decode())
         patch_generate_csr.assert_not_called()
 
-
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"  # noqa: E501, W505
     )
     @patch("charm.generate_csr")
     def test_given_csr_stored_when_config_changed_then_new_certificate_is_requested(
-        self,
-        patch_generate_csr,
-        patch_request_certificate_creation
+        self, patch_generate_csr, patch_request_certificate_creation
     ):
         self._add_model_secret(
             owner=self.harness.model.unit.name,
@@ -638,11 +629,10 @@ class TestCharmUnitMode(unittest.TestCase):
         csr_secret = self.harness.model.get_secret(label="csr-0").get_content(refresh=True)
         self.assertEqual(csr_secret["csr"], new_csr.decode())
 
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=new_csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=new_csr)
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505)
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505)
     )
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"  # noqa: E501, W505
@@ -689,9 +679,7 @@ class TestCharmUnitMode(unittest.TestCase):
 
 class TestCharmAppMode(unittest.TestCase):
     def setUp(self):
-        self.private_key = generate_private_key(
-            password=PRIVATE_KEY_PASSWORD.encode()
-        )
+        self.private_key = generate_private_key(password=PRIVATE_KEY_PASSWORD.encode())
         self.csr = generate_csr(
             sans_dns=[COMMON_NAME],
             common_name=COMMON_NAME,
@@ -757,7 +745,6 @@ class TestCharmAppMode(unittest.TestCase):
         self.assertEqual(secret_content["private-key"], self.private_key.decode())
         self.assertEqual(secret_content["private-key-password"], PRIVATE_KEY_PASSWORD)
 
-
     @patch("charm.generate_csr")
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"  # noqa: E501, W505
@@ -787,10 +774,7 @@ class TestCharmAppMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
-
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
     @patch("charm.generate_csr")
     @patch(
@@ -824,9 +808,7 @@ class TestCharmAppMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
     @patch("charm.generate_csr")
     @patch(
@@ -860,11 +842,10 @@ class TestCharmAppMode(unittest.TestCase):
             state_or_province_name=None,
             locality_name=None,
         )
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=self.csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=self.csr)
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
     )
     def test_given_certificate_request_is_made_when_evaluate_status_then_status_is_active(
         self,
@@ -911,7 +892,8 @@ class TestCharmAppMode(unittest.TestCase):
             ActiveStatus("App certificate request is sent"),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_csrs_match_when_on_certificate_available_then_certificate_is_stored(
         self,
@@ -964,9 +946,11 @@ class TestCharmAppMode(unittest.TestCase):
             self.csr.decode(),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
     )
     def test_given_certificate_stored_when_on_evaluate_status_then_status_is_active(
         self,
@@ -1012,7 +996,6 @@ class TestCharmAppMode(unittest.TestCase):
                 "country_name": COUNTRY_NAME,
                 "state_or_province_name": STATE_OR_PROVINCE_NAME,
                 "locality_name": LOCALITY_NAME,
-
             }
         )
 
@@ -1027,11 +1010,11 @@ class TestCharmAppMode(unittest.TestCase):
             ActiveStatus("App certificate is available"),
         )
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_certificate_already_stored_when_new_matching_certificate_available_then_certificate_is_overwritten(  # noqa: E501
-        self,
-        patch_get_assigned_certificates
+        self, patch_get_assigned_certificates
     ):
         self._add_model_secret(
             owner=self.harness.model.app.name,
@@ -1057,7 +1040,6 @@ class TestCharmAppMode(unittest.TestCase):
                 "country_name": COUNTRY_NAME,
                 "state_or_province_name": STATE_OR_PROVINCE_NAME,
                 "locality_name": LOCALITY_NAME,
-
             }
         )
         relation_id = self.harness.add_relation(
@@ -1093,7 +1075,8 @@ class TestCharmAppMode(unittest.TestCase):
 
         event.fail.assert_called()
 
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates"  # noqa: E501, W505
     )
     def test_given_certificate_is_stored_when_on_get_certificate_action_then_certificate_is_returned(  # noqa: E501
         self,
@@ -1202,9 +1185,7 @@ class TestCharmAppMode(unittest.TestCase):
     )
     @patch("charm.generate_csr")
     def test_given_csr_stored_when_config_changed_then_new_certificate_is_requested(
-        self,
-        patch_generate_csr,
-        patch_request_certificate_creation
+        self, patch_generate_csr, patch_request_certificate_creation
     ):
         self._add_model_secret(
             owner=self.harness.model.app.name,
@@ -1283,12 +1264,10 @@ class TestCharmAppMode(unittest.TestCase):
         csr_secret = self.harness.model.get_secret(label="csr").get_content(refresh=True)
         self.assertEqual(csr_secret["csr"], new_csr.decode())
 
-        patch_request_certificate_creation.assert_called_with(
-            certificate_signing_request=new_csr
-        )
+        patch_request_certificate_creation.assert_called_with(certificate_signing_request=new_csr)
 
-
-    @patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
+    @patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_certificate_signing_requests"  # noqa: E501, W505
     )
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"  # noqa: E501, W505

--- a/tests/unit/tls.py
+++ b/tests/unit/tls.py
@@ -19,9 +19,10 @@ def generate_private_key(password: bytes) -> bytes:
     key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.BestAvailableEncryption(password)
+        encryption_algorithm=serialization.BestAvailableEncryption(password),
     )
     return key_bytes
+
 
 def generate_csr(
     private_key: bytes,
@@ -30,7 +31,7 @@ def generate_csr(
     organization_name: str,
     email_address: str,
     country_name: str,
-    state_or_province_name:str,
+    state_or_province_name: str,
     locality_name: str,
     sans_dns: List[str],
 ) -> bytes:

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
