### PR TITLE
feat: add option to request multiple certificates per app (or unit)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -71,6 +71,9 @@ config:
       type: string
       description: |
         Common name to be used in the certificate.
+        This configuration option should not be set when `num_certificates` is greater than 1.
+        If set, only the leader unit will request the certificate with this common name.
+        Other units will not request certificates.
         If not set, the following value will be used (depending on the mode):
           - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
           - `app`: `<app name>-<certificate number>.<model name>`
@@ -79,6 +82,8 @@ config:
       type: string
       description: |
         Comma separated list of DNS Subject Alternative Names (SAN's) to be used in the certificate.
+        If set, only the leader unit will request the certificate with this common name.
+        Other units will not request certificates.
         If not set, the following value will be used (depending on the mode):
           - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
           - `app`: `<app name>-<certificate number>.<model name>`

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -60,6 +60,13 @@ config:
           - `unit`: Certificates are managed at the unit level. Each unit will have its own certificate.
           - `app`: Certificates are managed at the application level. The application can have 1 or more certificates.
 
+    num_certificates:
+      type: int
+      default: 1
+      description: |
+        Number of certificates to request.
+        If the mode is set to `unit`, each unit will request this number of certificates.
+
     common_name:
       type: string
       description: |


### PR DESCRIPTION
# Description

Here we add the option to request multiple certificates per app (or unit). Depending on the mode selected, the following values will be used for common name:
- **unit**: `<app name>-<unit number>-<certificate number>.<model name>`
- **app**: `<app name>-<certificate number>.<model name>`

Closes #23 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
