### PR TITLE
feat: support multiple certificate requests

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,8 +75,8 @@ config:
         If set, only the leader unit will request the certificate with this common name.
         Other units will not request certificates.
         If not set, the following value will be used (depending on the mode):
-          - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
-          - `app`: `<app name>-<certificate number>.<model name>`
+          - `unit`: `cert-<certificate number>.unit-<unit number>.<app name>.<model name>`
+          - `app`: `cert-<certificate number>.<app name>.<model name>`
 
     sans_dns:
       type: string
@@ -85,8 +85,8 @@ config:
         Other units will not request certificates.
         Comma separated list of DNS Subject Alternative Names (SAN's) to be used in the certificate.
         If not set, the following value will be used (depending on the mode):
-          - `unit`: ``<app name>-<unit number>-<certificate number>.<model name>`
-          - `app`: `<app name>-<certificate number>.<model name>`
+          - `unit`: `cert-<certificate number>.unit-<unit number>.<app name>.<model name>`
+          - `app`: `cert-<certificate number>.<app name>.<model name>`
 
     organization_name:
       type: string

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -51,6 +51,13 @@ requires:
 config:
   options:
 
+    num_certificates:
+      type: int
+      default: 1
+      description: |
+        Number of certificates to request.
+        If the mode is set to `unit`, each unit will request this number of certificates.
+
     mode:
       type: string
       default: "unit"
@@ -63,6 +70,7 @@ config:
     common_name:
       type: string
       description: |
+        This configuration option should not be set when `num_certificates` is greater than 1.
         Common name to be used in the certificate.
         If set, only the leader unit will request the certificate with this common name.
         Other units will not request certificates.

--- a/src/charm.py
+++ b/src/charm.py
@@ -212,10 +212,12 @@ class TLSRequirerCharm(CharmBase):
                         certificate_request=certificate_request
                     ),
                 )
-            logger.info("New certificate is stored: %s", str(assigned_certificate.certificate))
+            logger.info(
+                "New certificate is stored: %s", assigned_certificate.certificate.common_name
+            )
             return
         certificate_secret.set_content(content=certificate_secret_content)
-        logger.info("Certificate is updated: %s", str(assigned_certificate.certificate))
+        logger.info("Certificate is updated: %s", assigned_certificate.certificate.common_name)
 
     def _get_config_common_name(self) -> Optional[str]:
         """Return common name from the configuration."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class TLSRequirerCharm(CharmBase):
                     return
                 try:
                     certificate_secret.remove_all_revisions()
-                except SecretNotFoundError:
+                except (SecretNotFoundError, ModelError):
                     logger.warning(
                         "Unable to remove certificate secret: %s",
                         certificate_request.common_name,

--- a/src/charm.py
+++ b/src/charm.py
@@ -147,7 +147,8 @@ class TLSRequirerCharm(CharmBase):
 
     def _get_certificate_fulfillment_status(self) -> str:
         """Return the status message reflecting how many certificate requests are still pending."""
-        assigned_certificates_num = len(self.certificates.get_assigned_certificates())
+        assigned_certs, _ = self.certificates.get_assigned_certificates()
+        assigned_certificates_num = len(assigned_certs)
         certificate_requests_num = len(self._get_certificate_requests())
         return f"{assigned_certificates_num}/{certificate_requests_num} certificate requests are fulfilled"  # noqa: E501
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -232,18 +232,18 @@ class TLSRequirerCharm(CharmBase):
         """Return common name.
 
         If `common_name` config option is set, it will be used as a common name.
-        Otherwise, the common name will be generated based on the application name and unit number.
+        Otherwise, the common name will be generated based on the application name and unit number:
+        - `unit`: `cert-<certificate number>.unit-<unit number>.<app name>.<model name>`
+        - `app`: `cert-<certificate number>.<app name>.<model name>`
         """
         config_common_name = self._get_config_common_name()
         if config_common_name:
             return config_common_name
         mode = self._get_config_mode()
         if mode == Mode.UNIT:
-            return (
-                f"{self.app.name}-{self._get_unit_number()}-{certificate_number}.{self.model.name}"
-            )
+            return f"cert-{certificate_number}.unit-{self._get_unit_number()}.{self.app.name}.{self.model.name}"  # noqa: E501
         elif mode == Mode.APP:
-            return f"{self.app.name}-{certificate_number}.{self.model.name}"
+            return f"cert-{certificate_number}.{self.app.name}.{self.model.name}"
         raise ValueError("Invalid mode, only 'unit' and 'app' are allowed.")
 
     def _config_is_valid(self) -> Tuple[bool, str]:
@@ -278,7 +278,9 @@ class TLSRequirerCharm(CharmBase):
 
         If `sans_dns` config option is set, it will be used as a list of DNS
         Subject Alternative Names. Otherwise, the list will contain a single
-        DNS Subject Alternative Name based on the application name and unit number.
+        DNS Subject Alternative Name based on the application name and unit number:
+        - `unit`: `cert-<certificate number>.unit-<unit number>.<app name>.<model name>`
+        - `app`: `cert-<certificate number>.<app name>.<model name>`
         """
         config_sans_dns = self.model.config.get("sans_dns", "")
         if config_sans_dns and isinstance(config_sans_dns, str):
@@ -287,11 +289,11 @@ class TLSRequirerCharm(CharmBase):
         if mode == Mode.UNIT:
             return frozenset(
                 [
-                    f"{self.app.name}-{self._get_unit_number()}-{certificate_number}.{self.model.name}"
+                    f"cert-{certificate_number}.unit-{self._get_unit_number()}.{self.app.name}.{self.model.name}"
                 ]
             )
         elif mode == Mode.APP:
-            return frozenset([f"{self.app.name}-{certificate_number}.{self.model.name}"])
+            return frozenset([f"cert-{certificate_number}.{self.app.name}.{self.model.name}"])
         raise ValueError("Invalid mode, only 'unit' and 'app' are allowed.")
 
     def _get_config_organization_name(self) -> Optional[str]:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -183,6 +183,7 @@ class TestTLSRequirer:
 
         await tls_requirer_app.set_config(
             {
+                "mode": "unit",
                 "organization_name": "Ubuntu",
                 "email_address": "pizza@canonical.com",
                 "country_name": "CA",
@@ -191,7 +192,6 @@ class TestTLSRequirer:
             }
         )
 
-        leader_unit = await get_leader_unit(ops_test.model, self.APP_NAME)
         for unit in range(NUM_UNITS):
             expected_certificate_attributes = CertificateAttributes(
                 common_name=f"cert-0.unit-{unit}.{self.APP_NAME}.{ops_test.model.name}",
@@ -203,7 +203,7 @@ class TestTLSRequirer:
             )
             await wait_for_certificate_available(
                 ops_test=ops_test,
-                unit_name=leader_unit.name,
+                unit_name=f"{self.APP_NAME}/{unit}",
                 expected_certificate_attributes=expected_certificate_attributes,
             )
 
@@ -221,17 +221,22 @@ class TestTLSRequirer:
         await tls_requirer_app.set_config(
             {
                 "mode": "app",
+                "organization_name": "Ubuntu",
+                "email_address": "pizza@canonical.com",
+                "country_name": "CA",
+                "state_or_province_name": "Quebec",
+                "locality_name": "Montreal",
             }
         )
 
         leader_unit = await get_leader_unit(ops_test.model, self.APP_NAME)
         expected_certificate_attributes = CertificateAttributes(
             common_name=f"cert-0.{self.APP_NAME}.{ops_test.model.name}",
-            email_address=None,
-            organization_name="Canonical",
-            country_name="GB",
-            state_or_province_name="London",
-            locality_name="London",
+            email_address="pizza@canonical.com",
+            organization_name="Ubuntu",
+            country_name="CA",
+            state_or_province_name="Quebec",
+            locality_name="Montreal",
         )
         await wait_for_certificate_available(
             ops_test=ops_test,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -53,11 +53,7 @@ async def wait_for_certificates_available(
             logger.info("Certificates are not available")
             time.sleep(1)
             continue
-        print(certificates)
         certificate_list = json.loads(certificates)
-        print(certificate_list)
-        print(type(certificate_list))
-
         certs_obj = [Certificate(certificate["certificate"]) for certificate in certificate_list]
         for cert_obj in certs_obj:
             if not cert_obj.has_attributes(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -85,6 +85,10 @@ class TestCharmUnitMode:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.mock_tls_requires = TestCharmUnitMode.patcher_tls_requires.start()
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = (
+            [],
+            None,
+        )
 
     @pytest.fixture(autouse=True)
     def private_key_fixture(self):
@@ -193,12 +197,10 @@ class TestCharmUnitMode:
             revoked=False,
         )
         private_key = PrivateKey.from_string(self.private_key)
-        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = [
-            (
-                provider_certificate,
-                private_key,
-            )
-        ]
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = (
+            [provider_certificate],
+            private_key,
+        )
 
         certificate_secret = scenario.Secret(
             id="1",
@@ -487,6 +489,10 @@ class TestCharmAppMode:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.mock_tls_requires = TestCharmUnitMode.patcher_tls_requires.start()
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = (
+            [],
+            None,
+        )
 
     @pytest.fixture(autouse=True)
     def private_key_fixture(self):
@@ -619,12 +625,10 @@ class TestCharmAppMode:
         )
         private_key = PrivateKey.from_string(self.private_key)
 
-        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = [
-            (
-                provider_certificate,
-                private_key,
-            )
-        ]
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = (
+            [provider_certificate],
+            private_key,
+        )
 
         state_in = scenario.State(
             config={

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,9 +175,7 @@ class TestCharmUnitMode:
 
         state_out = self.ctx.run(event="collect_unit_status", state=state_in)
 
-        assert state_out.unit_status == ActiveStatus(
-            f"Waiting for unit certificate: tls-certificates-requirer-0-0.{model_name}"
-        )
+        assert state_out.unit_status == ActiveStatus("0/1 certificate requests are fulfilled")
 
     def test_given_certificate_stored_when_on_evaluate_status_then_status_is_active(self):
         certificates_relation = scenario.Relation(
@@ -195,10 +193,12 @@ class TestCharmUnitMode:
             revoked=False,
         )
         private_key = PrivateKey.from_string(self.private_key)
-        self.mock_tls_requires.return_value.get_assigned_certificate.return_value = (
-            provider_certificate,
-            private_key,
-        )
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = [
+            (
+                provider_certificate,
+                private_key,
+            )
+        ]
 
         certificate_secret = scenario.Secret(
             id="1",
@@ -221,9 +221,9 @@ class TestCharmUnitMode:
             secrets=[certificate_secret],
         )
 
-        state_out = self.ctx.run(event="update_status", state=state_in)
+        state_out = self.ctx.run(event="collect_unit_status", state=state_in)
 
-        assert state_out.unit_status == ActiveStatus("All unit certificates are available")
+        assert state_out.unit_status == ActiveStatus("1/1 certificate requests are fulfilled")
 
     def test_given_2_certificate_requests_when_update_status_then_2_certificates_with_appropriate_common_names_are_requested(  # noqa: E501
         self,
@@ -601,9 +601,7 @@ class TestCharmAppMode:
 
         state_out = self.ctx.run(event="collect_unit_status", state=state_in)
 
-        assert state_out.unit_status == ActiveStatus(
-            f"Waiting for app certificate: tls-certificates-requirer-0.{model_name}"
-        )
+        assert state_out.unit_status == ActiveStatus("0/1 certificate requests are fulfilled")
 
     def test_given_certificate_stored_when_on_evaluate_status_then_status_is_active(self):
         certificates_relation = scenario.Relation(
@@ -621,10 +619,12 @@ class TestCharmAppMode:
         )
         private_key = PrivateKey.from_string(self.private_key)
 
-        self.mock_tls_requires.return_value.get_assigned_certificate.return_value = (
-            provider_certificate,
-            private_key,
-        )
+        self.mock_tls_requires.return_value.get_assigned_certificates.return_value = [
+            (
+                provider_certificate,
+                private_key,
+            )
+        ]
 
         state_in = scenario.State(
             config={
@@ -640,9 +640,9 @@ class TestCharmAppMode:
             secrets=[],
         )
 
-        state_out = self.ctx.run(event="update_status", state=state_in)
+        state_out = self.ctx.run(event="collect_unit_status", state=state_in)
 
-        assert state_out.unit_status == ActiveStatus("All app certificates are available")
+        assert state_out.unit_status == ActiveStatus("1/1 certificate requests are fulfilled")
 
     def test_given_non_leader_when_update_status_then_no_certificate_is_requested(self):
         model_name = "abc"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -259,13 +259,19 @@ class TestCharmUnitMode:
         assert len(instance_calls) == 1
         _, kwargs = instance_calls[0]
         certificate_requests = kwargs["certificate_requests"]
-        assert certificate_requests[0].common_name == f"tls-certificates-requirer-0-0.{model_name}"
-        assert certificate_requests[0].sans_dns == frozenset(
-            {f"tls-certificates-requirer-0-0.{model_name}"}
+        assert (
+            certificate_requests[0].common_name
+            == f"cert-0.unit-0.tls-certificates-requirer.{model_name}"
         )
-        assert certificate_requests[1].common_name == f"tls-certificates-requirer-0-1.{model_name}"
+        assert certificate_requests[0].sans_dns == frozenset(
+            {f"cert-0.unit-0.tls-certificates-requirer.{model_name}"}
+        )
+        assert (
+            certificate_requests[1].common_name
+            == f"cert-1.unit-0.tls-certificates-requirer.{model_name}"
+        )
         assert certificate_requests[1].sans_dns == frozenset(
-            {f"tls-certificates-requirer-0-1.{model_name}"}
+            {f"cert-1.unit-0.tls-certificates-requirer.{model_name}"}
         )
 
     def test_given_csrs_match_when_on_certificate_available_then_certificate_is_stored(
@@ -305,7 +311,10 @@ class TestCharmUnitMode:
 
         state_out = self.ctx.run(event="update_status", state=state_in)
 
-        assert state_out.secrets[0].label == f"tls-certificates-requirer-0-0.{state_in.model.name}"
+        assert (
+            state_out.secrets[0].label
+            == f"cert-0.unit-0.tls-certificates-requirer.{state_in.model.name}"
+        )
         assert state_out.secrets[0].contents == {
             0: {"certificate": CERTIFICATE, "ca-certificate": CA, "csr": self.csr}
         }
@@ -319,7 +328,7 @@ class TestCharmUnitMode:
             contents={0: {"certificate": CERTIFICATE, "ca-certificate": CA}},
             owner="unit",
             revision=0,
-            label=f"tls-certificates-requirer-0-0.{model_name}",
+            label=f"cert-0.unit-0.tls-certificates-requirer.{model_name}",
         )
 
         certificates_relation = scenario.Relation(
@@ -403,7 +412,7 @@ class TestCharmUnitMode:
             contents={0: {"certificate": CERTIFICATE, "ca-certificate": CA, "csr": self.csr}},
             owner="unit",
             revision=0,
-            label=f"tls-certificates-requirer-0-0.{model_name}",
+            label=f"cert-0.unit-0.tls-certificates-requirer.{model_name}",
         )
         certificates_relation = scenario.Relation(
             endpoint="certificates",
@@ -459,7 +468,7 @@ class TestCharmUnitMode:
             contents={0: {"certificate": "whatever", "ca-certificate": CA}},
             owner="unit",
             revision=0,
-            label=f"tls-certificates-requirer-0-0.{model_name}",
+            label=f"cert-0.unit-0.tls-certificates-requirer.{model_name}",
         )
         certificates_relation = scenario.Relation(
             endpoint="certificates",
@@ -711,13 +720,17 @@ class TestCharmAppMode:
         assert len(instance_calls) == 1
         _, kwargs = instance_calls[0]
         certificate_requests = kwargs["certificate_requests"]
-        assert certificate_requests[0].common_name == f"tls-certificates-requirer-0.{model_name}"
-        assert certificate_requests[0].sans_dns == frozenset(
-            {f"tls-certificates-requirer-0.{model_name}"}
+        assert (
+            certificate_requests[0].common_name == f"cert-0.tls-certificates-requirer.{model_name}"
         )
-        assert certificate_requests[1].common_name == f"tls-certificates-requirer-1.{model_name}"
+        assert certificate_requests[0].sans_dns == frozenset(
+            {f"cert-0.tls-certificates-requirer.{model_name}"}
+        )
+        assert (
+            certificate_requests[1].common_name == f"cert-1.tls-certificates-requirer.{model_name}"
+        )
         assert certificate_requests[1].sans_dns == frozenset(
-            {f"tls-certificates-requirer-1.{model_name}"}
+            {f"cert-1.tls-certificates-requirer.{model_name}"}
         )
 
     def test_given_csrs_match_when_on_certificate_available_then_certificate_is_stored(
@@ -760,7 +773,9 @@ class TestCharmAppMode:
 
         state_out = self.ctx.run(event="update_status", state=state_in)
 
-        assert state_out.secrets[0].label == f"tls-certificates-requirer-0.{state_in.model.name}"
+        assert (
+            state_out.secrets[0].label == f"cert-0.tls-certificates-requirer.{state_in.model.name}"
+        )
         assert state_out.secrets[0].contents == {
             0: {"certificate": CERTIFICATE, "ca-certificate": CA, "csr": self.csr}
         }
@@ -774,7 +789,7 @@ class TestCharmAppMode:
             contents={0: {"certificate": CERTIFICATE, "ca-certificate": CA}},
             owner="app",
             revision=0,
-            label=f"tls-certificates-requirer-0.{model_name}",
+            label=f"cert-0.tls-certificates-requirer.{model_name}",
         )
         certificates_relation = scenario.Relation(
             endpoint="certificates",
@@ -858,7 +873,7 @@ class TestCharmAppMode:
             contents={0: {"certificate": CERTIFICATE, "ca-certificate": CA, "csr": self.csr}},
             owner="app",
             revision=0,
-            label=f"tls-certificates-requirer-0.{model_name}",
+            label=f"cert-0.tls-certificates-requirer.{model_name}",
         )
         certificates_relation = scenario.Relation(
             endpoint="certificates",
@@ -915,7 +930,7 @@ class TestCharmAppMode:
             contents={0: {"certificate": "whatever", "ca-certificate": CA}},
             owner="app",
             revision=0,
-            label=f"tls-certificates-requirer-0.{model_name}",
+            label=f"cert-0.tls-certificates-requirer.{model_name}",
         )
         certificates_relation = scenario.Relation(
             endpoint="certificates",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -436,13 +437,15 @@ class TestCharmUnitMode:
 
         assert action_output.success is True
         assert action_output.results == {
-            "certificates": [
-                {
-                    "certificate": CERTIFICATE,
-                    "ca-certificate": CA,
-                    "csr": self.csr,
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate": CERTIFICATE,
+                        "ca-certificate": CA,
+                        "csr": self.csr,
+                    }
+                ]
+            )
         }
 
     def test_given_certificate_is_stored_when_on_certificates_relation_broken_then_certificate_secret_is_removed(  # noqa: E501
@@ -888,13 +891,15 @@ class TestCharmAppMode:
 
         assert action_output.success is True
         assert action_output.results == {
-            "certificates": [
-                {
-                    "certificate": CERTIFICATE,
-                    "ca-certificate": CA,
-                    "csr": self.csr,
-                }
-            ]
+            "certificates": json.dumps(
+                [
+                    {
+                        "certificate": CERTIFICATE,
+                        "ca-certificate": CA,
+                        "csr": self.csr,
+                    }
+                ]
+            )
         }
 
     def test_given_certificate_is_stored_when_on_certificates_relation_broken_then_certificate_secret_is_removed(  # noqa: E501


### PR DESCRIPTION
# Description

Here we add the option to request multiple certificates per app (or unit). Depending on the mode selected, the following values will be used for common name:
- **unit**: `cert-<certificate number>.unit-<unit number>.<app name>.<model name>`
- **app**: `cert-<certificate number>.<app name>.<model name>`

Closes #23 
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
