### PR TITLE
feat: add support for requesting CA certificate

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -118,6 +118,12 @@ config:
         Locality name to be used in the certificate.
         If not set, no locality name will be used.
 
+    is_ca:
+      type: boolean
+      default: false
+      description: |
+        If set to true, the charm will request a certificate that can be used as a Certificate Authority (CA).
+
 actions:
   get-certificate:
     description: Returns the TLS Certificate.

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -161,6 +161,7 @@ from enum import Enum
 from typing import FrozenSet, List, MutableMapping, Optional, Tuple, Union
 
 from cryptography import x509
+from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
@@ -184,7 +185,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 6
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -352,9 +353,10 @@ class Certificate:
 
     raw: str
     common_name: str
-    sans_dns: Optional[FrozenSet[str]] = None
-    sans_ip: Optional[FrozenSet[str]] = None
-    sans_oid: Optional[FrozenSet[str]] = None
+    is_ca: bool = False
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -386,48 +388,54 @@ class Certificate:
         organization_name = certificate_object.subject.get_attributes_for_oid(
             NameOID.ORGANIZATION_NAME
         )
+        organizational_unit = certificate_object.subject.get_attributes_for_oid(
+            NameOID.ORGANIZATIONAL_UNIT_NAME
+        )
         email_address = certificate_object.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
-
+        sans_dns: List[str] = []
+        sans_ip: List[str] = []
+        sans_oid: List[str] = []
         try:
             sans = certificate_object.extensions.get_extension_for_class(
                 x509.SubjectAlternativeName
             ).value
-            sans_dns = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.DNSName)
-                if isinstance(san, x509.DNSName)
-            )
-            sans_ip = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.IPAddress)
-                if isinstance(san, x509.IPAddress)
-            )
-            sans_oid = frozenset(
-                str(san)
-                for san in sans.get_values_for_type(x509.RegisteredID)
-                if isinstance(san, x509.RegisteredID)
-            )
+            for san in sans:
+                if isinstance(san, x509.DNSName):
+                    sans_dns.append(san.value)
+                if isinstance(san, x509.IPAddress):
+                    sans_ip.append(str(san.value))
+                if isinstance(san, x509.RegisteredID):
+                    sans_oid.append(str(san.value))
         except x509.ExtensionNotFound:
             logger.debug("No SANs found in certificate")
-            sans_dns = None
-            sans_ip = None
-            sans_oid = None
+            sans_dns = []
+            sans_ip = []
+            sans_oid = []
         expiry_time = certificate_object.not_valid_after_utc
         validity_start_time = certificate_object.not_valid_before_utc
+        is_ca = False
+        try:
+            is_ca = certificate_object.extensions.get_extension_for_oid(
+                ExtensionOID.BASIC_CONSTRAINTS
+            ).value.ca  # type: ignore[reportAttributeAccessIssue]
+        except x509.ExtensionNotFound:
+            pass
 
         return cls(
             raw=certificate.strip(),
             common_name=str(common_name[0].value),
+            is_ca=is_ca,
             country_name=str(country_name[0].value) if country_name else None,
             state_or_province_name=str(state_or_province_name[0].value)
             if state_or_province_name
             else None,
             locality_name=str(locality_name[0].value) if locality_name else None,
             organization=str(organization_name[0].value) if organization_name else None,
+            organizational_unit=str(organizational_unit[0].value) if organizational_unit else None,
             email_address=str(email_address[0].value) if email_address else None,
-            sans_dns=sans_dns,
-            sans_ip=sans_ip,
-            sans_oid=sans_oid,
+            sans_dns=frozenset(sans_dns),
+            sans_ip=frozenset(sans_ip),
+            sans_oid=frozenset(sans_oid),
             expiry_time=expiry_time,
             validity_start_time=validity_start_time,
         )
@@ -448,7 +456,6 @@ class CertificateSigningRequest:
     country_name: Optional[str] = None
     state_or_province_name: Optional[str] = None
     locality_name: Optional[str] = None
-    is_ca: bool = False
 
     def __eq__(self, other: object) -> bool:
         """Check if two CertificateSigningRequest objects are equal."""
@@ -459,22 +466,6 @@ class CertificateSigningRequest:
     def __str__(self) -> str:
         """Return the CSR as a string."""
         return self.raw
-
-    def to_certificate_request(self) -> "CertificateRequest":
-        """Convert to a CertificateRequest object."""
-        return CertificateRequest(
-            common_name=self.common_name,
-            sans_dns=self.sans_dns,
-            sans_ip=self.sans_ip,
-            sans_oid=self.sans_oid,
-            email_address=self.email_address,
-            organization=self.organization,
-            organizational_unit=self.organizational_unit,
-            country_name=self.country_name,
-            state_or_province_name=self.state_or_province_name,
-            locality_name=self.locality_name,
-            is_ca=self.is_ca,
-        )
 
     @classmethod
     def from_string(cls, csr: str) -> "CertificateSigningRequest":
@@ -513,8 +504,8 @@ class CertificateSigningRequest:
             organization=str(organization_name[0].value) if organization_name else None,
             email_address=str(email_address[0].value) if email_address else None,
             sans_dns=sans_dns,
-            sans_ip=sans_ip if sans_ip else None,
-            sans_oid=sans_oid if sans_oid else None,
+            sans_ip=sans_ip,
+            sans_oid=sans_oid,
         )
 
     def matches_private_key(self, key: PrivateKey) -> bool:
@@ -579,9 +570,9 @@ class CertificateRequest:
     """
 
     common_name: str
-    sans_dns: Optional[FrozenSet[str]] = None
-    sans_ip: Optional[FrozenSet[str]] = None
-    sans_oid: Optional[FrozenSet[str]] = None
+    sans_dns: Optional[FrozenSet[str]] = frozenset()
+    sans_ip: Optional[FrozenSet[str]] = frozenset()
+    sans_oid: Optional[FrozenSet[str]] = frozenset()
     email_address: Optional[str] = None
     organization: Optional[str] = None
     organizational_unit: Optional[str] = None
@@ -596,59 +587,48 @@ class CertificateRequest:
             return False
         return True
 
-    def generate_csr(  # noqa: C901
+    def generate_csr(
         self,
         private_key: PrivateKey,
-        add_unique_id_to_subject_name: bool = True,
     ) -> CertificateSigningRequest:
         """Generate a CSR using private key and subject.
 
         Args:
             private_key (PrivateKey): Private key
-            add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
-                subject name. Always leave to "True" when the CSR is used to request certificates
-                using the tls-certificates relation.
 
         Returns:
             CertificateSigningRequest: CSR
         """
-        signing_key = serialization.load_pem_private_key(str(private_key).encode(), password=None)
-        subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, self.common_name)]
-        if add_unique_id_to_subject_name:
-            unique_identifier = uuid.uuid4()
-            subject_name.append(
-                x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
-            )
-        if self.organization:
-            subject_name.append(
-                x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, self.organization)
-            )
-        if self.email_address:
-            subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, self.email_address))
-        if self.country_name:
-            subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, self.country_name))
-        if self.state_or_province_name:
-            subject_name.append(
-                x509.NameAttribute(
-                    x509.NameOID.STATE_OR_PROVINCE_NAME, self.state_or_province_name
-                )
-            )
-        if self.locality_name:
-            subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, self.locality_name))
-        csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+        return generate_csr(
+            private_key=private_key,
+            common_name=self.common_name,
+            sans_dns=self.sans_dns,
+            sans_ip=self.sans_ip,
+            sans_oid=self.sans_oid,
+            email_address=self.email_address,
+            organization=self.organization,
+            organizational_unit=self.organizational_unit,
+            country_name=self.country_name,
+            state_or_province_name=self.state_or_province_name,
+            locality_name=self.locality_name,
+        )
 
-        _sans: List[x509.GeneralName] = []
-        if self.sans_oid:
-            _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in self.sans_oid])
-        if self.sans_ip:
-            _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in self.sans_ip])
-        if self.sans_dns:
-            _sans.extend([x509.DNSName(san) for san in self.sans_dns])
-        if _sans:
-            csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
-        signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
-        csr_str = signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
-        return CertificateSigningRequest.from_string(csr_str)
+    @classmethod
+    def from_csr(cls, csr: CertificateSigningRequest, is_ca: bool):
+        """Create a CertificateRequest object from a CSR."""
+        return cls(
+            common_name=csr.common_name,
+            sans_dns=csr.sans_dns,
+            sans_ip=csr.sans_ip,
+            sans_oid=csr.sans_oid,
+            email_address=csr.email_address,
+            organization=csr.organization,
+            organizational_unit=csr.organizational_unit,
+            country_name=csr.country_name,
+            state_or_province_name=csr.state_or_province_name,
+            locality_name=csr.locality_name,
+            is_ca=is_ca,
+        )
 
 
 @dataclass(frozen=True)
@@ -686,6 +666,7 @@ class RequirerCSR:
 
     relation_id: int
     certificate_signing_request: CertificateSigningRequest
+    is_ca: bool
 
 
 class CertificateAvailableEvent(EventBase):
@@ -780,7 +761,7 @@ def calculate_expiry_notification_time(
     return expiry_time - timedelta(hours=calculated_hours)
 
 
-def _generate_private_key(
+def generate_private_key(
     key_size: int = 2048,
     public_exponent: int = 65537,
 ) -> PrivateKey:
@@ -791,7 +772,7 @@ def _generate_private_key(
         public_exponent: Public exponent.
 
     Returns:
-        str: Private Key
+        PrivateKey: Private Key
     """
     private_key = rsa.generate_private_key(
         public_exponent=public_exponent,
@@ -803,6 +784,336 @@ def _generate_private_key(
         encryption_algorithm=serialization.NoEncryption(),
     )
     return PrivateKey.from_string(key_bytes.decode())
+
+
+def generate_csr(  # noqa: C901
+    private_key: PrivateKey,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    add_unique_id_to_subject_name: bool = True,
+) -> CertificateSigningRequest:
+    """Generate a CSR using private key and subject.
+
+    Args:
+        private_key (PrivateKey): Private key
+        common_name (str): Common name
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (Optional[str]): Country name
+        state_or_province_name (Optional[str]): State or province name
+        locality_name (Optional[str]): Locality name
+        add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
+            subject name. Always leave to "True" when the CSR is used to request certificates
+            using the tls-certificates relation.
+
+    Returns:
+        CertificateSigningRequest: CSR
+    """
+    signing_key = serialization.load_pem_private_key(str(private_key).encode(), password=None)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if add_unique_id_to_subject_name:
+        unique_identifier = uuid.uuid4()
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
+        )
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+    csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    csr_str = signed_certificate.public_bytes(serialization.Encoding.PEM).decode()
+    return CertificateSigningRequest.from_string(csr_str)
+
+
+def generate_ca(
+    private_key: PrivateKey,
+    validity: int,
+    common_name: str,
+    sans_dns: Optional[FrozenSet[str]] = frozenset(),
+    sans_ip: Optional[FrozenSet[str]] = frozenset(),
+    sans_oid: Optional[FrozenSet[str]] = frozenset(),
+    organization: Optional[str] = None,
+    organizational_unit: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
+) -> Certificate:
+    """Generate a self signed CA Certificate.
+
+    Args:
+        private_key (PrivateKey): Private key
+        validity (int): Certificate validity time (in days)
+        common_name (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
+        sans_dns (FrozenSet[str]): DNS Subject Alternative Names
+        sans_ip (FrozenSet[str]): IP Subject Alternative Names
+        sans_oid (FrozenSet[str]): OID Subject Alternative Names
+        organization (Optional[str]): Organization name
+        organizational_unit (Optional[str]): Organizational unit name
+        email_address (Optional[str]): Email address
+        country_name (str): Certificate Issuing country
+        state_or_province_name (str): Certificate Issuing state or province
+        locality_name (str): Certificate Issuing locality
+
+    Returns:
+        Certificate: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(
+        str(private_key).encode(), password=None
+    )
+    assert isinstance(private_key_object, rsa.RSAPrivateKey)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if organizational_unit:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organizational_unit)
+        )
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name(subject_name))
+        .issuer_name(x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name)]))
+        .public_key(private_key_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(key_usage, critical=True)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    ca_cert_str = cert.public_bytes(serialization.Encoding.PEM).decode().strip()
+    return Certificate.from_string(ca_cert_str)
+
+
+def generate_certificate(
+    csr: CertificateSigningRequest,
+    ca: Certificate,
+    ca_private_key: PrivateKey,
+    validity: int,
+    is_ca: bool = False,
+) -> Certificate:
+    """Generate a TLS certificate based on a CSR.
+
+    Args:
+        csr (CertificateSigningRequest): CSR
+        ca (Certificate): CA Certificate
+        ca_private_key (PrivateKey): CA private key
+        validity (int): Certificate validity (in days)
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        Certificate: Certificate
+    """
+    csr_object = x509.load_pem_x509_csr(str(csr).encode())
+    subject = csr_object.subject
+    ca_pem = x509.load_pem_x509_certificate(str(ca).encode())
+    issuer = ca_pem.issuer
+    private_key = serialization.load_pem_private_key(str(ca_private_key).encode(), password=None)
+
+    certificate_builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(csr_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+    )
+    extensions = _get_certificate_request_extensions(
+        authority_key_identifier=ca_pem.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value.key_identifier,
+        csr=csr_object,
+        is_ca=is_ca,
+    )
+    for extension in extensions:
+        try:
+            certificate_builder = certificate_builder.add_extension(
+                extval=extension.value,
+                critical=extension.critical,
+            )
+        except ValueError as e:
+            logger.warning("Failed to add extension %s: %s", extension.oid, e)
+
+    cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
+    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    return Certificate.from_string(cert_bytes.decode().strip())
+
+
+def _get_certificate_request_extensions(
+    authority_key_identifier: bytes,
+    csr: x509.CertificateSigningRequest,
+    is_ca: bool,
+) -> List[x509.Extension]:
+    """Generate a list of certificate extensions from a CSR and other known information.
+
+    Args:
+        authority_key_identifier (bytes): Authority key identifier
+        csr (x509.CertificateSigningRequest): CSR
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        List[x509.Extension]: List of extensions
+    """
+    cert_extensions_list: List[x509.Extension] = [
+        x509.Extension(
+            oid=ExtensionOID.AUTHORITY_KEY_IDENTIFIER,
+            value=x509.AuthorityKeyIdentifier(
+                key_identifier=authority_key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_KEY_IDENTIFIER,
+            value=x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.BASIC_CONSTRAINTS,
+            critical=True,
+            value=x509.BasicConstraints(ca=is_ca, path_length=None),
+        ),
+    ]
+    sans: List[x509.GeneralName] = []
+    try:
+        loaded_san_ext = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans.extend(
+            [x509.DNSName(name) for name in loaded_san_ext.value.get_values_for_type(x509.DNSName)]
+        )
+        sans.extend(
+            [x509.IPAddress(ip) for ip in loaded_san_ext.value.get_values_for_type(x509.IPAddress)]
+        )
+        sans.extend(
+            [
+                x509.RegisteredID(oid)
+                for oid in loaded_san_ext.value.get_values_for_type(x509.RegisteredID)
+            ]
+        )
+    except x509.ExtensionNotFound:
+        pass
+
+    if sans:
+        cert_extensions_list.append(
+            x509.Extension(
+                oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+                critical=False,
+                value=x509.SubjectAlternativeName(sans),
+            )
+        )
+
+    if is_ca:
+        cert_extensions_list.append(
+            x509.Extension(
+                ExtensionOID.KEY_USAGE,
+                critical=True,
+                value=x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+            )
+        )
+
+    existing_oids = {ext.oid for ext in cert_extensions_list}
+    for extension in csr.extensions:
+        if extension.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME:
+            continue
+        if extension.oid in existing_oids:
+            logger.warning("Extension %s is managed by the TLS provider, ignoring.", extension.oid)
+            continue
+        cert_extensions_list.append(extension)
+
+    return cert_extensions_list
 
 
 class CertificatesRequirerCharmEvents(CharmEvents):
@@ -939,7 +1250,7 @@ class TLSCertificatesRequiresV4(Object):
     def _generate_private_key(self) -> None:
         if self._private_key_generated():
             return
-        private_key = _generate_private_key()
+        private_key = generate_private_key()
         self.charm.unit.add_secret(
             content={"private-key": str(private_key)},
             label=self._get_private_key_secret_label(),
@@ -960,7 +1271,7 @@ class TLSCertificatesRequiresV4(Object):
 
     def _regenerate_private_key(self) -> None:
         secret = self.charm.model.get_secret(label=self._get_private_key_secret_label())
-        secret.set_content({"private-key": str(_generate_private_key())})
+        secret.set_content({"private-key": str(generate_private_key())})
 
     def _private_key_generated(self) -> bool:
         try:
@@ -969,9 +1280,14 @@ class TLSCertificatesRequiresV4(Object):
             return False
         return True
 
-    def _csr_matches_certificate_request(self, csr: CertificateSigningRequest) -> bool:
+    def _csr_matches_certificate_request(
+        self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
+    ) -> bool:
         for certificate_request in self.certificate_requests:
-            if csr.to_certificate_request() == certificate_request:
+            if certificate_request == CertificateRequest.from_csr(
+                certificate_signing_request,
+                is_ca,
+            ):
                 return True
         return False
 
@@ -981,19 +1297,23 @@ class TLSCertificatesRequiresV4(Object):
         csr = self._certificate_requested_for_attributes(certificate_request)
         if not csr:
             return False
-        if not csr.matches_private_key(key=self.private_key):
+        if not csr.certificate_signing_request.matches_private_key(key=self.private_key):
             return False
         return True
 
     def _certificate_requested_for_attributes(
-        self, certificate_request: CertificateRequest
-    ) -> Optional[CertificateSigningRequest]:
+        self,
+        certificate_request: CertificateRequest,
+    ) -> Optional[RequirerCSR]:
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if requirer_csr.to_certificate_request() == certificate_request:
+            if certificate_request == CertificateRequest.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
                 return requirer_csr
         return None
 
-    def get_csrs_from_requirer_relation_data(self) -> List[CertificateSigningRequest]:
+    def get_csrs_from_requirer_relation_data(self) -> List[RequirerCSR]:
         """Return list of requirer's CSRs from relation data."""
         if self.mode == Mode.APP and not self.model.unit.is_leader():
             logger.debug("Not a leader unit - Skipping")
@@ -1008,10 +1328,18 @@ class TLSCertificatesRequiresV4(Object):
         except DataValidationError:
             logger.warning("Invalid relation data")
             return []
-        return [
-            CertificateSigningRequest.from_string(csr.certificate_signing_request)
-            for csr in requirer_relation_data.certificate_signing_requests
-        ]
+        requirer_csrs = []
+        for csr in requirer_relation_data.certificate_signing_requests:
+            requirer_csrs.append(
+                RequirerCSR(
+                    relation_id=relation.id,
+                    certificate_signing_request=CertificateSigningRequest.from_string(
+                        csr.certificate_signing_request
+                    ),
+                    is_ca=csr.ca if csr.ca else False,
+                )
+            )
+        return requirer_csrs
 
     def get_provider_certificates(self) -> List[ProviderCertificate]:
         """Return list of certificates from the provider's relation data."""
@@ -1083,7 +1411,10 @@ class TLSCertificatesRequiresV4(Object):
     ) -> Tuple[ProviderCertificate | None, PrivateKey | None]:
         """Get the certificate that was assigned to the given certificate request."""
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if certificate_request == requirer_csr.to_certificate_request():
+            if certificate_request == CertificateRequest.from_csr(
+                requirer_csr.certificate_signing_request,
+                requirer_csr.is_ca,
+            ):
                 return self._find_certificate_in_relation_data(requirer_csr), self.private_key
         return None, None
 
@@ -1096,11 +1427,14 @@ class TLSCertificatesRequiresV4(Object):
         return assigned_certificates, self.private_key
 
     def _find_certificate_in_relation_data(
-        self, csr: CertificateSigningRequest
+        self, csr: RequirerCSR
     ) -> Optional[ProviderCertificate]:
         """Return the certificate that match the given CSR."""
         for provider_certificate in self.get_provider_certificates():
-            if provider_certificate.certificate_signing_request == csr:
+            if (
+                provider_certificate.certificate_signing_request == csr.certificate_signing_request
+                and provider_certificate.certificate.is_ca == csr.is_ca
+            ):
                 return provider_certificate
         return None
 
@@ -1112,9 +1446,10 @@ class TLSCertificatesRequiresV4(Object):
         If a certificate is revoked, the secret will be removed and an event will be emitted.
         """
         requirer_csrs = self.get_csrs_from_requirer_relation_data()
+        csrs = [csr.certificate_signing_request for csr in requirer_csrs]
         provider_certificates = self.get_provider_certificates()
         for provider_certificate in provider_certificates:
-            if provider_certificate.certificate_signing_request in requirer_csrs:
+            if provider_certificate.certificate_signing_request in csrs:
                 secret_label = self._get_csr_secret_label(
                     provider_certificate.certificate_signing_request
                 )
@@ -1128,7 +1463,8 @@ class TLSCertificatesRequiresV4(Object):
                         secret.remove_all_revisions()
                 else:
                     if not self._csr_matches_certificate_request(
-                        provider_certificate.certificate_signing_request
+                        certificate_signing_request=provider_certificate.certificate_signing_request,
+                        is_ca=provider_certificate.certificate.is_ca,
                     ):
                         logger.debug("Certificate requested for different attributes - Skipping")
                         continue
@@ -1170,17 +1506,27 @@ class TLSCertificatesRequiresV4(Object):
         - The CSR public key does not match the private key.
         """
         for requirer_csr in self.get_csrs_from_requirer_relation_data():
-            if not self._csr_matches_certificate_request(requirer_csr):
-                self._remove_requirer_csr_from_relation_data(requirer_csr)
-                logger.info(
-                    "Removed CSR from relation data because \
-                        it did not match any certificate request"
+            if not self._csr_matches_certificate_request(
+                certificate_signing_request=requirer_csr.certificate_signing_request,
+                is_ca=requirer_csr.is_ca,
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
                 )
-            elif self.private_key and not requirer_csr.matches_private_key(self.private_key):
-                self._remove_requirer_csr_from_relation_data(requirer_csr)
                 logger.info(
-                    "Removed CSR from relation data because \
-                        it did not match the private key"
+                    "Removed CSR from relation data because it did not match any certificate request"  # noqa: E501
+                )
+            elif (
+                self.private_key
+                and not requirer_csr.certificate_signing_request.matches_private_key(
+                    self.private_key
+                )
+            ):
+                self._remove_requirer_csr_from_relation_data(
+                    requirer_csr.certificate_signing_request
+                )
+                logger.info(
+                    "Removed CSR from relation data because it did not match the private key"  # noqa: E501
                 )
 
     def _get_next_secret_expiry_time(
@@ -1268,7 +1614,7 @@ class TLSCertificatesProvidesV4(Object):
         self._remove_certificates_for_which_no_csr_exists()
 
     def _remove_certificates_for_which_no_csr_exists(self) -> None:
-        provider_certificates = self._get_provider_certificates()
+        provider_certificates = self.get_provider_certificates()
         requirer_csrs = [
             request.certificate_signing_request for request in self.get_certificate_requests()
         ]
@@ -1317,6 +1663,7 @@ class TLSCertificatesProvidesV4(Object):
                 certificate_signing_request=CertificateSigningRequest.from_string(
                     csr.certificate_signing_request
                 ),
+                is_ca=csr.ca if csr.ca else False,
             )
             for csr in requirer_relation_data.certificate_signing_requests
         ]
@@ -1429,10 +1776,10 @@ class TLSCertificatesProvidesV4(Object):
         if not self.model.unit.is_leader():
             logger.warning("Unit is not a leader - will not read relation data")
             return []
-        provider_certificates = self._get_provider_certificates(relation_id=relation_id)
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
         return [certificate for certificate in provider_certificates if not certificate.revoked]
 
-    def _get_provider_certificates(
+    def get_provider_certificates(
         self, relation_id: Optional[int] = None
     ) -> List[ProviderCertificate]:
         """Return a List of issued certificates."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -162,6 +162,7 @@ class TLSRequirerCharm(CharmBase):
                 country_name=self._get_config_country_name(),
                 state_or_province_name=self._get_config_state_or_province_name(),
                 locality_name=self._get_config_locality_name(),
+                is_ca=self._get_config_is_ca(),
             )
             for i in range(self._get_config_num_certificates())
         ]
@@ -315,6 +316,13 @@ class TLSRequirerCharm(CharmBase):
     def _get_config_locality_name(self) -> Optional[str]:
         """Return locality name from the configuration."""
         return self._get_str_config("locality_name")
+
+    def _get_config_is_ca(self) -> bool:
+        """Return whether the certificate is a CA."""
+        is_ca = self.model.config.get("is_ca", False)
+        if not isinstance(is_ca, bool):
+            return False
+        return is_ca
 
     def _get_str_config(self, key: str) -> Optional[str]:
         """Return value of specified string juju config."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -226,7 +226,7 @@ class TestTLSRequirer:
                 "country_name": "CA",
                 "state_or_province_name": "Quebec",
                 "locality_name": "Montreal",
-                "is_ca": True,
+                "is_ca": "true",
             }
         )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -226,6 +226,7 @@ class TestTLSRequirer:
                 "country_name": "CA",
                 "state_or_province_name": "Quebec",
                 "locality_name": "Montreal",
+                "is_ca": True,
             }
         )
 
@@ -237,6 +238,7 @@ class TestTLSRequirer:
             country_name="CA",
             state_or_province_name="Quebec",
             locality_name="Montreal",
+            is_ca=True,
         )
         await wait_for_certificate_available(
             ops_test=ops_test,


### PR DESCRIPTION
# Description

Some TLS providers support providing CA certificates (ex. self-signed-certificates) and here we want to validate this behavior with tls certificates requirer. Having this feature here would permit identifying issues with the TLS library related to providing CA certificates. We add support for requesting CA certificates.

Fixes #171 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
