### PR TITLE
feat: Adds workflows to build and publish the charm on arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,15 +5,22 @@ on:
 
 jobs:
   build-charm-under-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
-    
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.20/stable
-    
+          channel: 5.20/stable
+
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
 
@@ -23,6 +30,6 @@ jobs:
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: "*.charm"
           retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,21 +5,28 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Fetch Charm Under Test
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: built/
-      
+
       - name: Get Charm Under Test Path
         id: charm-path
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
-      
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -27,7 +34,7 @@ jobs:
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
           lxd-channel: 5.20/stable
-  
+
       - name: Run integration tests
         run: |
           tox -e integration -- \
@@ -39,7 +46,7 @@ jobs:
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
-  
+
       - name: Archive juju crashdump
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -10,6 +10,12 @@ on:
           - edge -> beta
           - beta -> candidate
           - candidate -> stable
+      arch:
+        type: choice
+        description: Architecture
+        options:
+          - amd64
+          - arm64
 
 jobs:
   promote:
@@ -41,3 +47,4 @@ jobs:
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}
           charmcraft-channel: latest/stable
+          base-architecture: ${{ github.event.inputs.arch }}

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   publish-charm:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,8 +26,8 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
-      
+          name: built-charm-${{ matrix.arch.arch }}
+
       - name: Get Charm Under Test Path
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
@@ -36,7 +43,7 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-  
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,11 +29,25 @@ assumes:
 
 bases:
   - build-on:
-    - name: "ubuntu"
+    - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
     run-on:
-    - name: "ubuntu"
+    - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
 
 parts:
   charm:


### PR DESCRIPTION
# Description

Improves the CI to build, publish and test the charm for both architectures `amd64` and `arm64`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
