### PR TITLE
fix: Fix ExtensionOID import and the version of self-signed-certs in the integration tests

### DIFF
--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from cryptography import x509
-from cryptography.hazmat._oid import ExtensionOID
+from cryptography.x509.oid import ExtensionOID
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -106,7 +106,7 @@ class TestTLSRequirer:
         await ops_test.model.deploy(
             SELF_SIGNED_CERTIFICATES_CHARM_NAME,
             application_name=self.SELF_SIGNED_CERTIFICATES_APP_NAME,
-            channel="edge",
+            channel="1/edge",
             constraints={"arch": ARCH},
         )
         await ops_test.model.set_config(config={"update-status-hook-interval": "10s"})


### PR DESCRIPTION
# Description

- The CI is failing when trying to deploy `self-signed-certificates` from `edge`, we fix it by specifying `1/edge`
- ExtensionOID is now under cryptography.x509.oid

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
