### PR TITLE
chore: Update READMEs to link to official docs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
   unit-tests-with-coverage:
     uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@v1
 
-  build:
+  build-for-integration:
     needs:
       - lint-report
       - static-analysis
@@ -31,20 +31,57 @@ jobs:
     uses: ./.github/workflows/build.yaml
     secrets: inherit
 
+  build:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm-amd.yaml@v1
+    with:
+      path: ""
+
+  build-arm:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm-arm.yaml@v1
+    with:
+      path: ""
+
   integration-test:
     needs:
-      - build
+      - build-for-integration
     uses: ./.github/workflows/integration-test.yaml
 
-  publish-charm:
+  publish-charm-amd64:
     needs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
       - integration-test
+      - build
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v1
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v1
     with:
-      track-name: latest
+      destination_channel: latest/edge
+      artifacts-key: ${{ needs.build.outputs.artifacts-key }}
+      charm-paths: ${{ needs.build.outputs.charm-paths }}
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+
+  publish-charm-arm64:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+      - integration-test
+      - build-arm
+    if: ${{ github.ref_name == 'main' }}
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v1
+    with:
+      destination_channel: latest/edge
+      artifacts-key: ${{ needs.build-arm.outputs.artifacts-key }}
+      charm-paths: ${{ needs.build-arm.outputs.charm-paths }}
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TLS Certificates Requirer Operator
+
 [![CharmHub Badge](https://charmhub.io/tls-certificates-requirer/badge.svg)](https://charmhub.io/tls-certificates-requirer)
 
 Charm that requests X.509 certificates using the `tls-certificates` interface.
@@ -10,25 +11,12 @@ and provide it back into their application relation data.
 
 This charm is useful when developing and testing certificate providers.
 
-## Pre-requisites
+For more information, including guides, integrations, and configuration options, read the [TLS Certificates Requirer documentation](https://charmhub.io/tls-certificates-requirer).
 
-- Juju >= 3.0
+## Project & Community
 
-## Usage
+TLS Certificates Requirer Operator is an open source project that warmly welcomes community contributions, suggestions, fixes, and constructive feedback.
 
-Deploy the charm and relate it to a certificate provider:
-
-```bash
-juju deploy tls-certificates-requirer
-juju relate tls-certificates-requirer <TLS Certificates Provider>
-```
-
-Access the generated certificate:
-
-```bash
-juju run tls-certificates-requirer/leader get-certificate
-```
-
-## Relations
-
-- `tls-certificates`: Used for charms that require/provide TLS certificates.
+- To contribute to the code Please see [CONTRIBUTING.md](CONTRIBUTING.md) and the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines and best practices.
+- Raise software issues or feature requests in [GitHub](https://github.com/canonical/tls-certificates-requirer-operator/issues)
+- Meet the community and chat with us on [Matrix](https://matrix.to/#/#tls:ubuntu.com)


### PR DESCRIPTION
# Description

Remove docs from README and reference the official docs from charmhub instead

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
